### PR TITLE
fix: update headers in multiple files for gRPC compatibility

### DIFF
--- a/online-feature-store/internal/server/grpc/middleware.go
+++ b/online-feature-store/internal/server/grpc/middleware.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	AuthToken       = "AUTH_TOKEN"
-	callerIdHeader  = "online-feature-store-caller-id"
+	callerIdHeader  as "online-feature-store-caller-id" | "online_feature_store_caller_id"
 	AuthTokenHeader = "online-feature-store-auth-token"
 )
 

--- a/py-sdk/grpc_feature_client/grpc_feature_client/client.py
+++ b/py-sdk/grpc_feature_client/grpc_feature_client/client.py
@@ -20,8 +20,8 @@ from .config import GRPCClientConfig
 logger = logging.getLogger(__name__)
 
 # gRPC authentication headers (from Go SDK)
-HEADER_CALLER_ID = "ONLINE-FEATURE-STORE-CALLER-ID"
-HEADER_CALLER_TOKEN = "ONLINE-FEATURE-STORE-AUTH-TOKEN"
+HEADER_CALLER_ID = "online_feature_store_caller_id"
+HEADER_CALLER_TOKEN = "online_feature_store_auth_token"
 
 try:
     import grpc


### PR DESCRIPTION


## 📌 Summary

This PR fixes gRPC header compliance in Python by changing the header keys used by GRPCFeatureClient to lowercase (`caller_id`, `auth_token`). The previous uppercase headers with hyphens were rejected by the `grpcio` library due to HTTP/2 spec violations.

This fix enables Python clients to use the SDK without patching or subclassing.
---

## 📂 Modules Affected

<!-- Tick all that apply -->

- [ ] `horizon` (Real-time systems / networking)
- [ ] `online-feature-store` (Feature serving infra)
- [ ] `trufflebox-ui` (Admin panel / UI)
- [ ] `infra` (Docker, CI/CD, GCP/AWS setup)
- [ ] `docs` (Documentation updates)
- [ ] Other: `___________`

---

## ✅ Type of Change

- [ ] Feature addition
- [x] Bug fix
- [ ] Infra / build system change
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Other: `___________`

---



