### PR TITLE
Add Slate-aware config generation

### DIFF
--- a/horizon/internal/inferflow/etcd/models.go
+++ b/horizon/internal/inferflow/etcd/models.go
@@ -26,12 +26,13 @@ type ServiceConfigData struct {
 }
 
 type NumerixComponent struct {
-	Component    string            `json:"component"`
-	ComponentID  string            `json:"component_id"`
-	ScoreCol     string            `json:"score_col"`
-	ComputeID    string            `json:"compute_id"`
-	ScoreMapping map[string]string `json:"score_mapping"`
-	DataType     string            `json:"data_type"`
+	Component      string            `json:"component"`
+	ComponentID    string            `json:"component_id"`
+	ScoreCol       string            `json:"score_col"`
+	ComputeID      string            `json:"compute_id"`
+	ScoreMapping   map[string]string `json:"score_mapping"`
+	DataType       string            `json:"data_type"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type PredatorInput struct {
@@ -55,16 +56,17 @@ type RoutingConfig struct {
 }
 
 type PredatorComponent struct {
-	Component     string           `json:"component"`
-	ComponentID   string           `json:"component_id"`
-	ModelName     string           `json:"model_name"`
-	Calibration   string           `json:"calibration,omitempty"`
-	ModelEndPoint string           `json:"model_end_point"`
-	Deadline      int              `json:"deadline"`
-	BatchSize     int              `json:"batch_size"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	Component      string           `json:"component"`
+	ComponentID    string           `json:"component_id"`
+	ModelName      string           `json:"model_name"`
+	Calibration    string           `json:"calibration,omitempty"`
+	ModelEndPoint  string           `json:"model_end_point"`
+	Deadline       int              `json:"deadline"`
+	BatchSize      int              `json:"batch_size"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 type RTPComponent struct {

--- a/horizon/internal/inferflow/handler/adaptor.go
+++ b/horizon/internal/inferflow/handler/adaptor.go
@@ -212,16 +212,17 @@ func AdaptToDBPredatorComponent(inferflowConfig InferflowConfig) []dbModel.Preda
 		}
 
 		predatorComp := dbModel.PredatorComponent{
-			Component:     ranker.Component,
-			ComponentID:   ranker.ComponentID,
-			Calibration:   ranker.Calibration,
-			ModelName:     ranker.ModelName,
-			ModelEndPoint: ranker.ModelEndPoint,
-			Deadline:      ranker.Deadline,
-			BatchSize:     ranker.BatchSize,
-			Inputs:        dbInputs,
-			Outputs:       dbOutputs,
-			RoutingConfig: routingConfig,
+			Component:      ranker.Component,
+			ComponentID:    ranker.ComponentID,
+			Calibration:    ranker.Calibration,
+			ModelName:      ranker.ModelName,
+			ModelEndPoint:  ranker.ModelEndPoint,
+			Deadline:       ranker.Deadline,
+			BatchSize:      ranker.BatchSize,
+			Inputs:         dbInputs,
+			Outputs:        dbOutputs,
+			RoutingConfig:  routingConfig,
+			SlateComponent: ranker.SlateComponent,
 		}
 		predatorComponents = append(predatorComponents, predatorComp)
 	}
@@ -234,12 +235,13 @@ func AdaptToDBNumerixComponent(inferflowConfig InferflowConfig) []dbModel.Numeri
 
 	for _, reRanker := range inferflowConfig.ComponentConfig.NumerixComponents {
 		NumerixComp := dbModel.NumerixComponent{
-			Component:    reRanker.Component,
-			ComponentID:  reRanker.ComponentID,
-			ScoreCol:     reRanker.ScoreCol,
-			ComputeID:    reRanker.ComputeID,
-			ScoreMapping: reRanker.ScoreMapping,
-			DataType:     reRanker.DataType,
+			Component:      reRanker.Component,
+			ComponentID:    reRanker.ComponentID,
+			ScoreCol:       reRanker.ScoreCol,
+			ComputeID:      reRanker.ComputeID,
+			ScoreMapping:   reRanker.ScoreMapping,
+			DataType:       reRanker.DataType,
+			SlateComponent: reRanker.SlateComponent,
 		}
 		NumerixComponents = append(NumerixComponents, NumerixComp)
 	}
@@ -342,15 +344,16 @@ func AdaptToDBOnboardPayload(onboardPayload OnboardPayload) dbModel.OnboardPaylo
 
 	for i, ranker := range onboardPayload.Rankers {
 		dbOnboardPayload.Rankers[i] = dbModel.OnboardRanker{
-			ModelName:     ranker.ModelName,
-			Calibration:   ranker.Calibration,
-			EndPoint:      ranker.EndPoint,
-			EntityID:      ranker.EntityID,
-			Inputs:        make([]dbModel.PredatorInput, len(ranker.Inputs)),
-			Outputs:       make([]dbModel.PredatorOutput, len(ranker.Outputs)),
-			BatchSize:     ranker.BatchSize,
-			Deadline:      ranker.Deadline,
-			RoutingConfig: make([]dbModel.RoutingConfig, len(ranker.RoutingConfig)),
+			ModelName:      ranker.ModelName,
+			Calibration:    ranker.Calibration,
+			EndPoint:       ranker.EndPoint,
+			EntityID:       ranker.EntityID,
+			Inputs:         make([]dbModel.PredatorInput, len(ranker.Inputs)),
+			Outputs:        make([]dbModel.PredatorOutput, len(ranker.Outputs)),
+			BatchSize:      ranker.BatchSize,
+			Deadline:       ranker.Deadline,
+			RoutingConfig:  make([]dbModel.RoutingConfig, len(ranker.RoutingConfig)),
+			SlateComponent: ranker.SlateComponent,
 		}
 		for j, input := range ranker.Inputs {
 			dbOnboardPayload.Rankers[i].Inputs[j] = dbModel.PredatorInput{
@@ -379,11 +382,12 @@ func AdaptToDBOnboardPayload(onboardPayload OnboardPayload) dbModel.OnboardPaylo
 	}
 	for i, reRanker := range onboardPayload.ReRankers {
 		dbOnboardPayload.ReRankers[i] = dbModel.OnboardReRanker{
-			Score:       reRanker.Score,
-			EqID:        reRanker.EqID,
-			EqVariables: reRanker.EqVariables,
-			DataType:    reRanker.DataType,
-			EntityID:    reRanker.EntityID,
+			Score:          reRanker.Score,
+			EqID:           reRanker.EqID,
+			EqVariables:    reRanker.EqVariables,
+			DataType:       reRanker.DataType,
+			EntityID:       reRanker.EntityID,
+			SlateComponent: reRanker.SlateComponent,
 		}
 	}
 	return dbOnboardPayload
@@ -422,15 +426,16 @@ func AdaptFromDbToOnboardPayload(dbOnboardPayload dbModel.OnboardPayload) Onboar
 
 	for i, predatorComponent := range dbOnboardPayload.Rankers {
 		onboardPayload.Rankers = append(onboardPayload.Rankers, Ranker{
-			ModelName:     predatorComponent.ModelName,
-			Calibration:   predatorComponent.Calibration,
-			EndPoint:      predatorComponent.EndPoint,
-			Inputs:        make([]Input, len(predatorComponent.Inputs)),
-			Outputs:       make([]Output, len(predatorComponent.Outputs)),
-			EntityID:      predatorComponent.EntityID,
-			BatchSize:     predatorComponent.BatchSize,
-			Deadline:      predatorComponent.Deadline,
-			RoutingConfig: make([]RoutingConfig, len(predatorComponent.RoutingConfig)),
+			ModelName:      predatorComponent.ModelName,
+			Calibration:    predatorComponent.Calibration,
+			EndPoint:       predatorComponent.EndPoint,
+			Inputs:         make([]Input, len(predatorComponent.Inputs)),
+			Outputs:        make([]Output, len(predatorComponent.Outputs)),
+			EntityID:       predatorComponent.EntityID,
+			BatchSize:      predatorComponent.BatchSize,
+			Deadline:       predatorComponent.Deadline,
+			RoutingConfig:  make([]RoutingConfig, len(predatorComponent.RoutingConfig)),
+			SlateComponent: predatorComponent.SlateComponent,
 		})
 		for j, input := range predatorComponent.Inputs {
 			onboardPayload.Rankers[i].Inputs[j] = Input{
@@ -460,11 +465,12 @@ func AdaptFromDbToOnboardPayload(dbOnboardPayload dbModel.OnboardPayload) Onboar
 
 	for _, reRanker := range dbOnboardPayload.ReRankers {
 		onboardPayload.ReRankers = append(onboardPayload.ReRankers, ReRanker{
-			Score:       reRanker.Score,
-			EqID:        reRanker.EqID,
-			EqVariables: reRanker.EqVariables,
-			DataType:    reRanker.DataType,
-			EntityID:    reRanker.EntityID,
+			Score:          reRanker.Score,
+			EqID:           reRanker.EqID,
+			EqVariables:    reRanker.EqVariables,
+			DataType:       reRanker.DataType,
+			EntityID:       reRanker.EntityID,
+			SlateComponent: reRanker.SlateComponent,
 		})
 	}
 
@@ -536,16 +542,17 @@ func AdaptFromDbToPredatorComponent(dbPredatorComponents []dbModel.PredatorCompo
 		}
 
 		predatorComponent := PredatorComponent{
-			Component:     predatorComponent.Component,
-			ComponentID:   predatorComponent.ComponentID,
-			ModelName:     predatorComponent.ModelName,
-			ModelEndPoint: predatorComponent.ModelEndPoint,
-			Calibration:   predatorComponent.Calibration,
-			Deadline:      predatorComponent.Deadline,
-			BatchSize:     predatorComponent.BatchSize,
-			Inputs:        dbInputs,
-			Outputs:       dbOutputs,
-			RoutingConfig: routingConfig,
+			Component:      predatorComponent.Component,
+			ComponentID:    predatorComponent.ComponentID,
+			ModelName:      predatorComponent.ModelName,
+			ModelEndPoint:  predatorComponent.ModelEndPoint,
+			Calibration:    predatorComponent.Calibration,
+			Deadline:       predatorComponent.Deadline,
+			BatchSize:      predatorComponent.BatchSize,
+			Inputs:         dbInputs,
+			Outputs:        dbOutputs,
+			RoutingConfig:  routingConfig,
+			SlateComponent: predatorComponent.SlateComponent,
 		}
 		predatorComponents = append(predatorComponents, predatorComponent)
 	}
@@ -557,12 +564,13 @@ func AdaptFromDbToNumerixComponent(dbNumerixComponents []dbModel.NumerixComponen
 	var NumerixComponents []NumerixComponent
 	for _, numerixComponent := range dbNumerixComponents {
 		numerixComponent := NumerixComponent{
-			Component:    numerixComponent.Component,
-			ComponentID:  numerixComponent.ComponentID,
-			ScoreCol:     numerixComponent.ScoreCol,
-			ComputeID:    numerixComponent.ComputeID,
-			ScoreMapping: numerixComponent.ScoreMapping,
-			DataType:     numerixComponent.DataType,
+			Component:      numerixComponent.Component,
+			ComponentID:    numerixComponent.ComponentID,
+			ScoreCol:       numerixComponent.ScoreCol,
+			ComputeID:      numerixComponent.ComputeID,
+			ScoreMapping:   numerixComponent.ScoreMapping,
+			DataType:       numerixComponent.DataType,
+			SlateComponent: numerixComponent.SlateComponent,
 		}
 		NumerixComponents = append(NumerixComponents, numerixComponent)
 	}
@@ -690,16 +698,17 @@ func AdaptToEtcdPredatorComponent(dbPredatorComponents []dbModel.PredatorCompone
 		}
 
 		predatorComponent := etcdModel.PredatorComponent{
-			Component:     predatorComponent.Component,
-			ComponentID:   predatorComponent.ComponentID,
-			Calibration:   predatorComponent.Calibration,
-			ModelName:     predatorComponent.ModelName,
-			ModelEndPoint: predatorComponent.ModelEndPoint,
-			Deadline:      predatorComponent.Deadline,
-			BatchSize:     predatorComponent.BatchSize,
-			Inputs:        dbInputs,
-			Outputs:       dbOutputs,
-			RoutingConfig: routingConfig,
+			Component:      predatorComponent.Component,
+			ComponentID:    predatorComponent.ComponentID,
+			Calibration:    predatorComponent.Calibration,
+			ModelName:      predatorComponent.ModelName,
+			ModelEndPoint:  predatorComponent.ModelEndPoint,
+			Deadline:       predatorComponent.Deadline,
+			BatchSize:      predatorComponent.BatchSize,
+			Inputs:         dbInputs,
+			Outputs:        dbOutputs,
+			RoutingConfig:  routingConfig,
+			SlateComponent: predatorComponent.SlateComponent,
 		}
 		predatorComponents = append(predatorComponents, predatorComponent)
 	}
@@ -711,12 +720,13 @@ func AdaptToEtcdNumerixComponent(dbNumerixComponents []dbModel.NumerixComponent)
 	var NumerixComponents []etcdModel.NumerixComponent
 	for _, NumerixComponent := range dbNumerixComponents {
 		NumerixComponent := etcdModel.NumerixComponent{
-			Component:    NumerixComponent.Component,
-			ComponentID:  NumerixComponent.ComponentID,
-			ScoreCol:     NumerixComponent.ScoreCol,
-			ComputeID:    NumerixComponent.ComputeID,
-			ScoreMapping: NumerixComponent.ScoreMapping,
-			DataType:     NumerixComponent.DataType,
+			Component:      NumerixComponent.Component,
+			ComponentID:    NumerixComponent.ComponentID,
+			ScoreCol:       NumerixComponent.ScoreCol,
+			ComputeID:      NumerixComponent.ComputeID,
+			ScoreMapping:   NumerixComponent.ScoreMapping,
+			DataType:       NumerixComponent.DataType,
+			SlateComponent: NumerixComponent.SlateComponent,
 		}
 		NumerixComponents = append(NumerixComponents, NumerixComponent)
 	}

--- a/horizon/internal/inferflow/handler/config_builder.go
+++ b/horizon/internal/inferflow/handler/config_builder.go
@@ -918,15 +918,16 @@ func GetPredatorComponents(request InferflowOnboardRequest, offlineToOnlineMappi
 		}
 
 		predatorComponent := PredatorComponent{
-			Component:     "p" + strconv.Itoa(i+1),
-			ComponentID:   strings.Join(ranker.EntityID, COLON_DELIMITER),
-			ModelName:     ranker.ModelName,
-			ModelEndPoint: ranker.EndPoint,
-			Deadline:      ranker.Deadline,
-			BatchSize:     ranker.BatchSize,
-			Inputs:        make([]PredatorInput, 0, len(ranker.Inputs)),
-			Outputs:       make([]PredatorOutput, 0, len(ranker.Outputs)),
-			RoutingConfig: ranker.RoutingConfig,
+			Component:      "p" + strconv.Itoa(i+1),
+			ComponentID:    strings.Join(ranker.EntityID, COLON_DELIMITER),
+			ModelName:      ranker.ModelName,
+			ModelEndPoint:  ranker.EndPoint,
+			Deadline:       ranker.Deadline,
+			BatchSize:      ranker.BatchSize,
+			Inputs:         make([]PredatorInput, 0, len(ranker.Inputs)),
+			Outputs:        make([]PredatorOutput, 0, len(ranker.Outputs)),
+			RoutingConfig:  ranker.RoutingConfig,
+			SlateComponent: ranker.SlateComponent,
 		}
 
 		if ranker.Calibration != "" {
@@ -988,12 +989,13 @@ func GetNumerixComponents(request InferflowOnboardRequest, offlineToOnlineMappin
 			return nil, err
 		}
 		NumerixComponent := NumerixComponent{
-			Component:    "i" + strconv.Itoa(i+1),
-			ComponentID:  strings.Join(reRanker.EntityID, COLON_DELIMITER),
-			ScoreCol:     reRanker.Score,
-			ComputeID:    strconv.Itoa(reRanker.EqID),
-			ScoreMapping: scoremap,
-			DataType:     reRanker.DataType,
+			Component:      "i" + strconv.Itoa(i+1),
+			ComponentID:    strings.Join(reRanker.EntityID, COLON_DELIMITER),
+			ScoreCol:       reRanker.Score,
+			ComputeID:      strconv.Itoa(reRanker.EqID),
+			ScoreMapping:   scoremap,
+			DataType:       reRanker.DataType,
+			SlateComponent: reRanker.SlateComponent,
 		}
 		NumerixComponents = append(NumerixComponents, NumerixComponent)
 	}

--- a/horizon/internal/inferflow/handler/models.go
+++ b/horizon/internal/inferflow/handler/models.go
@@ -27,23 +27,25 @@ type RoutingConfig struct {
 }
 
 type Ranker struct {
-	ModelName     string          `json:"model_name"`
-	BatchSize     int             `json:"batch_size"`
-	Deadline      int             `json:"deadline"`
-	Calibration   string          `json:"calibration"`
-	EndPoint      string          `json:"end_point"`
-	Inputs        []Input         `json:"inputs"`
-	Outputs       []Output        `json:"outputs"`
-	EntityID      []string        `json:"entity_id"`
-	RoutingConfig []RoutingConfig `json:"route_config"`
+	ModelName      string          `json:"model_name"`
+	BatchSize      int             `json:"batch_size"`
+	Deadline       int             `json:"deadline"`
+	Calibration    string          `json:"calibration"`
+	EndPoint       string          `json:"end_point"`
+	Inputs         []Input         `json:"inputs"`
+	Outputs        []Output        `json:"outputs"`
+	EntityID       []string        `json:"entity_id"`
+	RoutingConfig  []RoutingConfig `json:"route_config"`
+	SlateComponent bool            `json:"slate_component"`
 }
 
 type ReRanker struct {
-	EqVariables map[string]string `json:"eq_variables"`
-	Score       string            `json:"score"`
-	EqID        int               `json:"eq_id"`
-	DataType    string            `json:"data_type"`
-	EntityID    []string          `json:"entity_id"`
+	EqVariables    map[string]string `json:"eq_variables"`
+	Score          string            `json:"score"`
+	EqID           int               `json:"eq_id"`
+	DataType       string            `json:"data_type"`
+	EntityID       []string          `json:"entity_id"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type ResponseConfig struct {
@@ -100,12 +102,13 @@ type Response struct {
 }
 
 type NumerixComponent struct {
-	Component    string            `json:"component"`
-	ComponentID  string            `json:"component_id"`
-	ScoreCol     string            `json:"score_col"`
-	ComputeID    string            `json:"compute_id"`
-	ScoreMapping map[string]string `json:"score_mapping"`
-	DataType     string            `json:"data_type"`
+	Component      string            `json:"component"`
+	ComponentID    string            `json:"component_id"`
+	ScoreCol       string            `json:"score_col"`
+	ComputeID      string            `json:"compute_id"`
+	ScoreMapping   map[string]string `json:"score_mapping"`
+	DataType       string            `json:"data_type"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type PredatorInput struct {
@@ -123,16 +126,17 @@ type PredatorOutput struct {
 }
 
 type PredatorComponent struct {
-	Component     string           `json:"component"`
-	ComponentID   string           `json:"component_id"`
-	ModelName     string           `json:"model_name"`
-	ModelEndPoint string           `json:"model_end_point"`
-	Calibration   string           `json:"calibration,omitempty"`
-	Deadline      int              `json:"deadline"`
-	BatchSize     int              `json:"batch_size"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	Component      string           `json:"component"`
+	ComponentID    string           `json:"component_id"`
+	ModelName      string           `json:"model_name"`
+	ModelEndPoint  string           `json:"model_end_point"`
+	Calibration    string           `json:"calibration,omitempty"`
+	Deadline       int              `json:"deadline"`
+	BatchSize      int              `json:"batch_size"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 type FinalResponseConfig struct {

--- a/horizon/internal/repositories/sql/inferflow/models.go
+++ b/horizon/internal/repositories/sql/inferflow/models.go
@@ -11,12 +11,13 @@ type DagExecutionConfig struct {
 }
 
 type NumerixComponent struct {
-	Component    string            `json:"component"`
-	ComponentID  string            `json:"component_id"`
-	ScoreCol     string            `json:"score_col"`
-	ComputeID    string            `json:"compute_id"`
-	ScoreMapping map[string]string `json:"score_mapping"`
-	DataType     string            `json:"data_type"`
+	Component      string            `json:"component"`
+	ComponentID    string            `json:"component_id"`
+	ScoreCol       string            `json:"score_col"`
+	ComputeID      string            `json:"compute_id"`
+	ScoreMapping   map[string]string `json:"score_mapping"`
+	DataType       string            `json:"data_type"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type PredatorInput struct {
@@ -40,16 +41,17 @@ type RoutingConfig struct {
 }
 
 type PredatorComponent struct {
-	Component     string           `json:"component"`
-	ComponentID   string           `json:"component_id"`
-	ModelName     string           `json:"model_name"`
-	ModelEndPoint string           `json:"model_end_point"`
-	Calibration   string           `json:"calibration,omitempty"`
-	Deadline      int              `json:"deadline"`
-	BatchSize     int              `json:"batch_size"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	Component      string           `json:"component"`
+	ComponentID    string           `json:"component_id"`
+	ModelName      string           `json:"model_name"`
+	ModelEndPoint  string           `json:"model_end_point"`
+	Calibration    string           `json:"calibration,omitempty"`
+	Deadline       int              `json:"deadline"`
+	BatchSize      int              `json:"batch_size"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 type ResponseConfig struct {
@@ -144,23 +146,25 @@ type OnboardPayload struct {
 }
 
 type OnboardRanker struct {
-	ModelName     string           `json:"model_name"`
-	BatchSize     int              `json:"batch_size"`
-	Deadline      int              `json:"deadline"`
-	Calibration   string           `json:"calibration"`
-	EndPoint      string           `json:"end_point"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	EntityID      []string         `json:"entity_id"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	ModelName      string           `json:"model_name"`
+	BatchSize      int              `json:"batch_size"`
+	Deadline       int              `json:"deadline"`
+	Calibration    string           `json:"calibration"`
+	EndPoint       string           `json:"end_point"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	EntityID       []string         `json:"entity_id"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 type OnboardReRanker struct {
-	EqVariables map[string]string `json:"eq_variables"`
-	Score       string            `json:"score"`
-	EqID        int               `json:"eq_id"`
-	DataType    string            `json:"data_type"`
-	EntityID    []string          `json:"entity_id"`
+	EqVariables    map[string]string `json:"eq_variables"`
+	Score          string            `json:"score"`
+	EqID           int               `json:"eq_id"`
+	DataType       string            `json:"data_type"`
+	EntityID       []string          `json:"entity_id"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type Payload struct {

--- a/horizon/pkg/configschemaclient/types.go
+++ b/horizon/pkg/configschemaclient/types.go
@@ -30,12 +30,13 @@ type ResponseConfig struct {
 
 // NumerixComponent represents a Numerix/Numerix component
 type NumerixComponent struct {
-	Component    string            `json:"component"`
-	ComponentID  string            `json:"component_id"`
-	ScoreCol     string            `json:"score_col"`
-	ComputeID    string            `json:"compute_id"`
-	ScoreMapping map[string]string `json:"score_mapping"`
-	DataType     string            `json:"data_type"`
+	Component      string            `json:"component"`
+	ComponentID    string            `json:"component_id"`
+	ScoreCol       string            `json:"score_col"`
+	ComputeID      string            `json:"compute_id"`
+	ScoreMapping   map[string]string `json:"score_mapping"`
+	DataType       string            `json:"data_type"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 // FeatureComponent represents a feature store component
@@ -74,16 +75,17 @@ type SeenScoreComponent struct {
 
 // PredatorComponent represents a Predator model component
 type PredatorComponent struct {
-	Component     string           `json:"component"`
-	ComponentID   string           `json:"component_id"`
-	ModelName     string           `json:"model_name"`
-	ModelEndPoint string           `json:"model_end_point"`
-	Calibration   string           `json:"calibration,omitempty"`
-	Deadline      int              `json:"deadline"`
-	BatchSize     int              `json:"batch_size"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	Component      string           `json:"component"`
+	ComponentID    string           `json:"component_id"`
+	ModelName      string           `json:"model_name"`
+	ModelEndPoint  string           `json:"model_end_point"`
+	Calibration    string           `json:"calibration,omitempty"`
+	Deadline       int              `json:"deadline"`
+	BatchSize      int              `json:"batch_size"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 // PredatorInput represents input configuration for Predator

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/CloneInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/CloneInferflowConfigModal.jsx
@@ -508,6 +508,7 @@ const CloneInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => 
         batch_size: '',
         deadline: '110',
         entity_id: [],
+        slate_component: false,
         inputs: [{
           name: '',
           features: [],
@@ -544,7 +545,8 @@ const CloneInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => 
         score: '',
         data_type: 'DataTypeFP32',
         eq_id: '',
-        entity_id: []
+        entity_id: [],
+        slate_component: false
       }]
     }));
     setExpandedReRankers(prev => [...prev, newIndex]);

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/EditInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/EditInferflowConfigModal.jsx
@@ -515,6 +515,7 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
         batch_size: '',
         deadline: '110',
         entity_id: [],
+        slate_component: false,
         inputs: [{
           name: '',
           features: [],
@@ -551,7 +552,8 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
         score: '',
         data_type: 'DataTypeFP32',
         eq_id: '',
-        entity_id: []
+        entity_id: [],
+        slate_component: false
       }]
     }));
     setExpandedReRankers(prev => [...prev, newIndex]);

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/InferflowConfigForm.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/InferflowConfigForm.jsx
@@ -14,6 +14,8 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  FormControlLabel,
+  Switch,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -430,6 +432,18 @@ const InferflowConfigForm = ({
                     type="number"
                     value={ranker.deadline}
                     onChange={(e) => handleRankerChange(rankerIndex, 'deadline', e.target.value)}
+                  />
+                </Grid>
+                <Grid item xs={4}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={ranker.slate_component || false}
+                        onChange={(e) => handleRankerChange(rankerIndex, 'slate_component', e.target.checked)}
+                        color="primary"
+                      />
+                    }
+                    label="Slate Component"
                   />
                 </Grid>
               </Grid>
@@ -1060,6 +1074,19 @@ const InferflowConfigForm = ({
                   />
                 </Grid>
                 
+                <Grid item xs={12}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={reRanker.slate_component || false}
+                        onChange={(e) => handleReRankerChange(index, 'slate_component', e.target.checked)}
+                        color="secondary"
+                      />
+                    }
+                    label="Slate Component"
+                  />
+                </Grid>
+
                 {/* Entity IDs for re-ranker */}
                 <Grid item xs={12}>
                   <Box sx={{ mt: 2 }}>

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/OnboardInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/OnboardInferflowConfigModal.jsx
@@ -37,6 +37,7 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
       batch_size: '',
       deadline: '110',
       entity_id: [],
+      slate_component: false,
       inputs: [{
         name: '',
         features: [],
@@ -434,6 +435,7 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
         batch_size: '',
         deadline: '110',
         entity_id: [],
+        slate_component: false,
         inputs: [{
           name: '',
           features: [],
@@ -472,7 +474,8 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
         score: '',
         data_type: 'DataTypeFP32',
         eq_id: '',
-        entity_id: []
+        entity_id: [],
+        slate_component: false
       }]
     }));
     // Expand the newly added re-ranker


### PR DESCRIPTION
# 🔁 Pull Request Template – BharatMLStack

## Context:
Inferflow supports slate-level inference (e.g. `InferSlateWise`, pair-wise) in addition to target-level scoring. Downstream config and response building need to know which components (rankers, re-rankers, predator, numerix) are **slate components** vs target-level so that slate output columns and target output columns are handled correctly. This change adds **slate-awareness** to Inferflow config: a `slate_component` flag is introduced and wired through backend storage, config building, and the Trufflebox UI so operators can mark components as slate-level when onboarding or editing configs.

## Describe your changes:
- **Horizon (backend)**  
  - **Models:** Added `SlateComponent bool` to `Ranker`, `ReRanker`, `NumerixComponent`, and Predator-related structs in:
    - `horizon/internal/inferflow/handler/models.go`
    - `horizon/internal/inferflow/etcd/models.go`
    - `horizon/internal/repositories/sql/inferflow/models.go`
    - `horizon/pkg/configschemaclient/types.go` (NumerixComponent, PredatorComponent)
  - **Config flow:** Propagate `SlateComponent` in:
    - `horizon/internal/inferflow/handler/adaptor.go` (when mapping to config schema client types)
    - `horizon/internal/inferflow/handler/config_builder.go` (when building config from DB/etcd)
  - Ensures stored config and config served to Inferflow runtime carry the slate-component flag end-to-end.

- **Trufflebox UI (frontend)**  
  - **InferflowConfigForm.jsx:** Added “Slate Component” checkbox for each ranker and each re-ranker; value is bound to `ranker.slate_component` and `reRanker.slate_component` and included in submit payloads.
  - **OnboardInferflowConfigModal.jsx, EditInferflowConfigModal.jsx, CloneInferflowConfigModal.jsx:** Default and map `slate_component: false` for rankers and re-rankers when initializing or transforming payloads so existing flows remain unchanged and new configs can opt in to slate component.


## Checklist before requesting a review
- [x] I have reviewed my own changes?
- [ ] Relevant or critical functionality is covered by tests?
- [ ] Monitoring needs have been evaluated?
- [ ] Any necessary documentation updates have been considered?

## 📂 Modules Affected
<!-- Tick all that apply -->
- [x] `horizon` (Real-time systems / networking)
- [ ] `online-feature-store` (Feature serving infra)
- [x] `trufflebox-ui` (Admin panel / UI)
- [ ] `infra` (Docker, CI/CD, GCP/AWS setup)
- [ ] `docs` (Documentation updates)
- [ ] Other: `___________`

---

## ✅ Type of Change

- [x] Feature addition
- [ ] Bug fix
- [ ] Infra / build system change
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Other: `___________`

---

## 📊 Benchmark / Metrics (if applicable)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Slate Component configuration option for InferFlow ranking components. Users can now enable or disable slate component functionality individually for rankers and re-rankers through toggle controls in the configuration interface. The setting is properly maintained and synchronized across all InferFlow workflows including creation, cloning, editing, and import operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->