### PR TITLE
Add Slate-aware config generation

### DIFF
--- a/horizon/internal/inferflow/etcd/models.go
+++ b/horizon/internal/inferflow/etcd/models.go
@@ -26,12 +26,13 @@ type ServiceConfigData struct {
 }
 
 type NumerixComponent struct {
-	Component    string            `json:"component"`
-	ComponentID  string            `json:"component_id"`
-	ScoreCol     string            `json:"score_col"`
-	ComputeID    string            `json:"compute_id"`
-	ScoreMapping map[string]string `json:"score_mapping"`
-	DataType     string            `json:"data_type"`
+	Component      string            `json:"component"`
+	ComponentID    string            `json:"component_id"`
+	ScoreCol       string            `json:"score_col"`
+	ComputeID      string            `json:"compute_id"`
+	ScoreMapping   map[string]string `json:"score_mapping"`
+	DataType       string            `json:"data_type"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type PredatorInput struct {
@@ -55,16 +56,17 @@ type RoutingConfig struct {
 }
 
 type PredatorComponent struct {
-	Component     string           `json:"component"`
-	ComponentID   string           `json:"component_id"`
-	ModelName     string           `json:"model_name"`
-	Calibration   string           `json:"calibration,omitempty"`
-	ModelEndPoint string           `json:"model_end_point"`
-	Deadline      int              `json:"deadline"`
-	BatchSize     int              `json:"batch_size"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	Component      string           `json:"component"`
+	ComponentID    string           `json:"component_id"`
+	ModelName      string           `json:"model_name"`
+	Calibration    string           `json:"calibration,omitempty"`
+	ModelEndPoint  string           `json:"model_end_point"`
+	Deadline       int              `json:"deadline"`
+	BatchSize      int              `json:"batch_size"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 type RTPComponent struct {

--- a/horizon/internal/inferflow/handler/adaptor.go
+++ b/horizon/internal/inferflow/handler/adaptor.go
@@ -212,16 +212,17 @@ func AdaptToDBPredatorComponent(inferflowConfig InferflowConfig) []dbModel.Preda
 		}
 
 		predatorComp := dbModel.PredatorComponent{
-			Component:     ranker.Component,
-			ComponentID:   ranker.ComponentID,
-			Calibration:   ranker.Calibration,
-			ModelName:     ranker.ModelName,
-			ModelEndPoint: ranker.ModelEndPoint,
-			Deadline:      ranker.Deadline,
-			BatchSize:     ranker.BatchSize,
-			Inputs:        dbInputs,
-			Outputs:       dbOutputs,
-			RoutingConfig: routingConfig,
+			Component:      ranker.Component,
+			ComponentID:    ranker.ComponentID,
+			Calibration:    ranker.Calibration,
+			ModelName:      ranker.ModelName,
+			ModelEndPoint:  ranker.ModelEndPoint,
+			Deadline:       ranker.Deadline,
+			BatchSize:      ranker.BatchSize,
+			Inputs:         dbInputs,
+			Outputs:        dbOutputs,
+			RoutingConfig:  routingConfig,
+			SlateComponent: ranker.SlateComponent,
 		}
 		predatorComponents = append(predatorComponents, predatorComp)
 	}
@@ -234,12 +235,13 @@ func AdaptToDBNumerixComponent(inferflowConfig InferflowConfig) []dbModel.Numeri
 
 	for _, reRanker := range inferflowConfig.ComponentConfig.NumerixComponents {
 		NumerixComp := dbModel.NumerixComponent{
-			Component:    reRanker.Component,
-			ComponentID:  reRanker.ComponentID,
-			ScoreCol:     reRanker.ScoreCol,
-			ComputeID:    reRanker.ComputeID,
-			ScoreMapping: reRanker.ScoreMapping,
-			DataType:     reRanker.DataType,
+			Component:      reRanker.Component,
+			ComponentID:    reRanker.ComponentID,
+			ScoreCol:       reRanker.ScoreCol,
+			ComputeID:      reRanker.ComputeID,
+			ScoreMapping:   reRanker.ScoreMapping,
+			DataType:       reRanker.DataType,
+			SlateComponent: reRanker.SlateComponent,
 		}
 		NumerixComponents = append(NumerixComponents, NumerixComp)
 	}
@@ -342,15 +344,16 @@ func AdaptToDBOnboardPayload(onboardPayload OnboardPayload) dbModel.OnboardPaylo
 
 	for i, ranker := range onboardPayload.Rankers {
 		dbOnboardPayload.Rankers[i] = dbModel.OnboardRanker{
-			ModelName:     ranker.ModelName,
-			Calibration:   ranker.Calibration,
-			EndPoint:      ranker.EndPoint,
-			EntityID:      ranker.EntityID,
-			Inputs:        make([]dbModel.PredatorInput, len(ranker.Inputs)),
-			Outputs:       make([]dbModel.PredatorOutput, len(ranker.Outputs)),
-			BatchSize:     ranker.BatchSize,
-			Deadline:      ranker.Deadline,
-			RoutingConfig: make([]dbModel.RoutingConfig, len(ranker.RoutingConfig)),
+			ModelName:      ranker.ModelName,
+			Calibration:    ranker.Calibration,
+			EndPoint:       ranker.EndPoint,
+			EntityID:       ranker.EntityID,
+			Inputs:         make([]dbModel.PredatorInput, len(ranker.Inputs)),
+			Outputs:        make([]dbModel.PredatorOutput, len(ranker.Outputs)),
+			BatchSize:      ranker.BatchSize,
+			Deadline:       ranker.Deadline,
+			RoutingConfig:  make([]dbModel.RoutingConfig, len(ranker.RoutingConfig)),
+			SlateComponent: ranker.SlateComponent,
 		}
 		for j, input := range ranker.Inputs {
 			dbOnboardPayload.Rankers[i].Inputs[j] = dbModel.PredatorInput{
@@ -379,11 +382,12 @@ func AdaptToDBOnboardPayload(onboardPayload OnboardPayload) dbModel.OnboardPaylo
 	}
 	for i, reRanker := range onboardPayload.ReRankers {
 		dbOnboardPayload.ReRankers[i] = dbModel.OnboardReRanker{
-			Score:       reRanker.Score,
-			EqID:        reRanker.EqID,
-			EqVariables: reRanker.EqVariables,
-			DataType:    reRanker.DataType,
-			EntityID:    reRanker.EntityID,
+			Score:          reRanker.Score,
+			EqID:           reRanker.EqID,
+			EqVariables:    reRanker.EqVariables,
+			DataType:       reRanker.DataType,
+			EntityID:       reRanker.EntityID,
+			SlateComponent: reRanker.SlateComponent,
 		}
 	}
 	return dbOnboardPayload
@@ -422,15 +426,16 @@ func AdaptFromDbToOnboardPayload(dbOnboardPayload dbModel.OnboardPayload) Onboar
 
 	for i, predatorComponent := range dbOnboardPayload.Rankers {
 		onboardPayload.Rankers = append(onboardPayload.Rankers, Ranker{
-			ModelName:     predatorComponent.ModelName,
-			Calibration:   predatorComponent.Calibration,
-			EndPoint:      predatorComponent.EndPoint,
-			Inputs:        make([]Input, len(predatorComponent.Inputs)),
-			Outputs:       make([]Output, len(predatorComponent.Outputs)),
-			EntityID:      predatorComponent.EntityID,
-			BatchSize:     predatorComponent.BatchSize,
-			Deadline:      predatorComponent.Deadline,
-			RoutingConfig: make([]RoutingConfig, len(predatorComponent.RoutingConfig)),
+			ModelName:      predatorComponent.ModelName,
+			Calibration:    predatorComponent.Calibration,
+			EndPoint:       predatorComponent.EndPoint,
+			Inputs:         make([]Input, len(predatorComponent.Inputs)),
+			Outputs:        make([]Output, len(predatorComponent.Outputs)),
+			EntityID:       predatorComponent.EntityID,
+			BatchSize:      predatorComponent.BatchSize,
+			Deadline:       predatorComponent.Deadline,
+			RoutingConfig:  make([]RoutingConfig, len(predatorComponent.RoutingConfig)),
+			SlateComponent: predatorComponent.SlateComponent,
 		})
 		for j, input := range predatorComponent.Inputs {
 			onboardPayload.Rankers[i].Inputs[j] = Input{
@@ -460,11 +465,12 @@ func AdaptFromDbToOnboardPayload(dbOnboardPayload dbModel.OnboardPayload) Onboar
 
 	for _, reRanker := range dbOnboardPayload.ReRankers {
 		onboardPayload.ReRankers = append(onboardPayload.ReRankers, ReRanker{
-			Score:       reRanker.Score,
-			EqID:        reRanker.EqID,
-			EqVariables: reRanker.EqVariables,
-			DataType:    reRanker.DataType,
-			EntityID:    reRanker.EntityID,
+			Score:          reRanker.Score,
+			EqID:           reRanker.EqID,
+			EqVariables:    reRanker.EqVariables,
+			DataType:       reRanker.DataType,
+			EntityID:       reRanker.EntityID,
+			SlateComponent: reRanker.SlateComponent,
 		})
 	}
 
@@ -536,16 +542,17 @@ func AdaptFromDbToPredatorComponent(dbPredatorComponents []dbModel.PredatorCompo
 		}
 
 		predatorComponent := PredatorComponent{
-			Component:     predatorComponent.Component,
-			ComponentID:   predatorComponent.ComponentID,
-			ModelName:     predatorComponent.ModelName,
-			ModelEndPoint: predatorComponent.ModelEndPoint,
-			Calibration:   predatorComponent.Calibration,
-			Deadline:      predatorComponent.Deadline,
-			BatchSize:     predatorComponent.BatchSize,
-			Inputs:        dbInputs,
-			Outputs:       dbOutputs,
-			RoutingConfig: routingConfig,
+			Component:      predatorComponent.Component,
+			ComponentID:    predatorComponent.ComponentID,
+			ModelName:      predatorComponent.ModelName,
+			ModelEndPoint:  predatorComponent.ModelEndPoint,
+			Calibration:    predatorComponent.Calibration,
+			Deadline:       predatorComponent.Deadline,
+			BatchSize:      predatorComponent.BatchSize,
+			Inputs:         dbInputs,
+			Outputs:        dbOutputs,
+			RoutingConfig:  routingConfig,
+			SlateComponent: predatorComponent.SlateComponent,
 		}
 		predatorComponents = append(predatorComponents, predatorComponent)
 	}
@@ -557,12 +564,13 @@ func AdaptFromDbToNumerixComponent(dbNumerixComponents []dbModel.NumerixComponen
 	var NumerixComponents []NumerixComponent
 	for _, numerixComponent := range dbNumerixComponents {
 		numerixComponent := NumerixComponent{
-			Component:    numerixComponent.Component,
-			ComponentID:  numerixComponent.ComponentID,
-			ScoreCol:     numerixComponent.ScoreCol,
-			ComputeID:    numerixComponent.ComputeID,
-			ScoreMapping: numerixComponent.ScoreMapping,
-			DataType:     numerixComponent.DataType,
+			Component:      numerixComponent.Component,
+			ComponentID:    numerixComponent.ComponentID,
+			ScoreCol:       numerixComponent.ScoreCol,
+			ComputeID:      numerixComponent.ComputeID,
+			ScoreMapping:   numerixComponent.ScoreMapping,
+			DataType:       numerixComponent.DataType,
+			SlateComponent: numerixComponent.SlateComponent,
 		}
 		NumerixComponents = append(NumerixComponents, numerixComponent)
 	}
@@ -690,16 +698,17 @@ func AdaptToEtcdPredatorComponent(dbPredatorComponents []dbModel.PredatorCompone
 		}
 
 		predatorComponent := etcdModel.PredatorComponent{
-			Component:     predatorComponent.Component,
-			ComponentID:   predatorComponent.ComponentID,
-			Calibration:   predatorComponent.Calibration,
-			ModelName:     predatorComponent.ModelName,
-			ModelEndPoint: predatorComponent.ModelEndPoint,
-			Deadline:      predatorComponent.Deadline,
-			BatchSize:     predatorComponent.BatchSize,
-			Inputs:        dbInputs,
-			Outputs:       dbOutputs,
-			RoutingConfig: routingConfig,
+			Component:      predatorComponent.Component,
+			ComponentID:    predatorComponent.ComponentID,
+			Calibration:    predatorComponent.Calibration,
+			ModelName:      predatorComponent.ModelName,
+			ModelEndPoint:  predatorComponent.ModelEndPoint,
+			Deadline:       predatorComponent.Deadline,
+			BatchSize:      predatorComponent.BatchSize,
+			Inputs:         dbInputs,
+			Outputs:        dbOutputs,
+			RoutingConfig:  routingConfig,
+			SlateComponent: predatorComponent.SlateComponent,
 		}
 		predatorComponents = append(predatorComponents, predatorComponent)
 	}
@@ -711,12 +720,13 @@ func AdaptToEtcdNumerixComponent(dbNumerixComponents []dbModel.NumerixComponent)
 	var NumerixComponents []etcdModel.NumerixComponent
 	for _, NumerixComponent := range dbNumerixComponents {
 		NumerixComponent := etcdModel.NumerixComponent{
-			Component:    NumerixComponent.Component,
-			ComponentID:  NumerixComponent.ComponentID,
-			ScoreCol:     NumerixComponent.ScoreCol,
-			ComputeID:    NumerixComponent.ComputeID,
-			ScoreMapping: NumerixComponent.ScoreMapping,
-			DataType:     NumerixComponent.DataType,
+			Component:      NumerixComponent.Component,
+			ComponentID:    NumerixComponent.ComponentID,
+			ScoreCol:       NumerixComponent.ScoreCol,
+			ComputeID:      NumerixComponent.ComputeID,
+			ScoreMapping:   NumerixComponent.ScoreMapping,
+			DataType:       NumerixComponent.DataType,
+			SlateComponent: NumerixComponent.SlateComponent,
 		}
 		NumerixComponents = append(NumerixComponents, NumerixComponent)
 	}

--- a/horizon/internal/inferflow/handler/config_builder.go
+++ b/horizon/internal/inferflow/handler/config_builder.go
@@ -918,15 +918,16 @@ func GetPredatorComponents(request InferflowOnboardRequest, offlineToOnlineMappi
 		}
 
 		predatorComponent := PredatorComponent{
-			Component:     "p" + strconv.Itoa(i+1),
-			ComponentID:   strings.Join(ranker.EntityID, COLON_DELIMITER),
-			ModelName:     ranker.ModelName,
-			ModelEndPoint: ranker.EndPoint,
-			Deadline:      ranker.Deadline,
-			BatchSize:     ranker.BatchSize,
-			Inputs:        make([]PredatorInput, 0, len(ranker.Inputs)),
-			Outputs:       make([]PredatorOutput, 0, len(ranker.Outputs)),
-			RoutingConfig: ranker.RoutingConfig,
+			Component:      "p" + strconv.Itoa(i+1),
+			ComponentID:    strings.Join(ranker.EntityID, COLON_DELIMITER),
+			ModelName:      ranker.ModelName,
+			ModelEndPoint:  ranker.EndPoint,
+			Deadline:       ranker.Deadline,
+			BatchSize:      ranker.BatchSize,
+			Inputs:         make([]PredatorInput, 0, len(ranker.Inputs)),
+			Outputs:        make([]PredatorOutput, 0, len(ranker.Outputs)),
+			RoutingConfig:  ranker.RoutingConfig,
+			SlateComponent: ranker.SlateComponent,
 		}
 
 		if ranker.Calibration != "" {
@@ -988,12 +989,13 @@ func GetNumerixComponents(request InferflowOnboardRequest, offlineToOnlineMappin
 			return nil, err
 		}
 		NumerixComponent := NumerixComponent{
-			Component:    "i" + strconv.Itoa(i+1),
-			ComponentID:  strings.Join(reRanker.EntityID, COLON_DELIMITER),
-			ScoreCol:     reRanker.Score,
-			ComputeID:    strconv.Itoa(reRanker.EqID),
-			ScoreMapping: scoremap,
-			DataType:     reRanker.DataType,
+			Component:      "i" + strconv.Itoa(i+1),
+			ComponentID:    strings.Join(reRanker.EntityID, COLON_DELIMITER),
+			ScoreCol:       reRanker.Score,
+			ComputeID:      strconv.Itoa(reRanker.EqID),
+			ScoreMapping:   scoremap,
+			DataType:       reRanker.DataType,
+			SlateComponent: reRanker.SlateComponent,
 		}
 		NumerixComponents = append(NumerixComponents, NumerixComponent)
 	}

--- a/horizon/internal/inferflow/handler/models.go
+++ b/horizon/internal/inferflow/handler/models.go
@@ -27,23 +27,25 @@ type RoutingConfig struct {
 }
 
 type Ranker struct {
-	ModelName     string          `json:"model_name"`
-	BatchSize     int             `json:"batch_size"`
-	Deadline      int             `json:"deadline"`
-	Calibration   string          `json:"calibration"`
-	EndPoint      string          `json:"end_point"`
-	Inputs        []Input         `json:"inputs"`
-	Outputs       []Output        `json:"outputs"`
-	EntityID      []string        `json:"entity_id"`
-	RoutingConfig []RoutingConfig `json:"route_config"`
+	ModelName      string          `json:"model_name"`
+	BatchSize      int             `json:"batch_size"`
+	Deadline       int             `json:"deadline"`
+	Calibration    string          `json:"calibration"`
+	EndPoint       string          `json:"end_point"`
+	Inputs         []Input         `json:"inputs"`
+	Outputs        []Output        `json:"outputs"`
+	EntityID       []string        `json:"entity_id"`
+	RoutingConfig  []RoutingConfig `json:"route_config"`
+	SlateComponent bool            `json:"slate_component"`
 }
 
 type ReRanker struct {
-	EqVariables map[string]string `json:"eq_variables"`
-	Score       string            `json:"score"`
-	EqID        int               `json:"eq_id"`
-	DataType    string            `json:"data_type"`
-	EntityID    []string          `json:"entity_id"`
+	EqVariables    map[string]string `json:"eq_variables"`
+	Score          string            `json:"score"`
+	EqID           int               `json:"eq_id"`
+	DataType       string            `json:"data_type"`
+	EntityID       []string          `json:"entity_id"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type ResponseConfig struct {
@@ -100,12 +102,13 @@ type Response struct {
 }
 
 type NumerixComponent struct {
-	Component    string            `json:"component"`
-	ComponentID  string            `json:"component_id"`
-	ScoreCol     string            `json:"score_col"`
-	ComputeID    string            `json:"compute_id"`
-	ScoreMapping map[string]string `json:"score_mapping"`
-	DataType     string            `json:"data_type"`
+	Component      string            `json:"component"`
+	ComponentID    string            `json:"component_id"`
+	ScoreCol       string            `json:"score_col"`
+	ComputeID      string            `json:"compute_id"`
+	ScoreMapping   map[string]string `json:"score_mapping"`
+	DataType       string            `json:"data_type"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type PredatorInput struct {
@@ -123,16 +126,17 @@ type PredatorOutput struct {
 }
 
 type PredatorComponent struct {
-	Component     string           `json:"component"`
-	ComponentID   string           `json:"component_id"`
-	ModelName     string           `json:"model_name"`
-	ModelEndPoint string           `json:"model_end_point"`
-	Calibration   string           `json:"calibration,omitempty"`
-	Deadline      int              `json:"deadline"`
-	BatchSize     int              `json:"batch_size"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	Component      string           `json:"component"`
+	ComponentID    string           `json:"component_id"`
+	ModelName      string           `json:"model_name"`
+	ModelEndPoint  string           `json:"model_end_point"`
+	Calibration    string           `json:"calibration,omitempty"`
+	Deadline       int              `json:"deadline"`
+	BatchSize      int              `json:"batch_size"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 type FinalResponseConfig struct {

--- a/horizon/internal/repositories/sql/inferflow/models.go
+++ b/horizon/internal/repositories/sql/inferflow/models.go
@@ -11,12 +11,13 @@ type DagExecutionConfig struct {
 }
 
 type NumerixComponent struct {
-	Component    string            `json:"component"`
-	ComponentID  string            `json:"component_id"`
-	ScoreCol     string            `json:"score_col"`
-	ComputeID    string            `json:"compute_id"`
-	ScoreMapping map[string]string `json:"score_mapping"`
-	DataType     string            `json:"data_type"`
+	Component      string            `json:"component"`
+	ComponentID    string            `json:"component_id"`
+	ScoreCol       string            `json:"score_col"`
+	ComputeID      string            `json:"compute_id"`
+	ScoreMapping   map[string]string `json:"score_mapping"`
+	DataType       string            `json:"data_type"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type PredatorInput struct {
@@ -40,16 +41,17 @@ type RoutingConfig struct {
 }
 
 type PredatorComponent struct {
-	Component     string           `json:"component"`
-	ComponentID   string           `json:"component_id"`
-	ModelName     string           `json:"model_name"`
-	ModelEndPoint string           `json:"model_end_point"`
-	Calibration   string           `json:"calibration,omitempty"`
-	Deadline      int              `json:"deadline"`
-	BatchSize     int              `json:"batch_size"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	Component      string           `json:"component"`
+	ComponentID    string           `json:"component_id"`
+	ModelName      string           `json:"model_name"`
+	ModelEndPoint  string           `json:"model_end_point"`
+	Calibration    string           `json:"calibration,omitempty"`
+	Deadline       int              `json:"deadline"`
+	BatchSize      int              `json:"batch_size"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 type ResponseConfig struct {
@@ -144,23 +146,25 @@ type OnboardPayload struct {
 }
 
 type OnboardRanker struct {
-	ModelName     string           `json:"model_name"`
-	BatchSize     int              `json:"batch_size"`
-	Deadline      int              `json:"deadline"`
-	Calibration   string           `json:"calibration"`
-	EndPoint      string           `json:"end_point"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	EntityID      []string         `json:"entity_id"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	ModelName      string           `json:"model_name"`
+	BatchSize      int              `json:"batch_size"`
+	Deadline       int              `json:"deadline"`
+	Calibration    string           `json:"calibration"`
+	EndPoint       string           `json:"end_point"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	EntityID       []string         `json:"entity_id"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 type OnboardReRanker struct {
-	EqVariables map[string]string `json:"eq_variables"`
-	Score       string            `json:"score"`
-	EqID        int               `json:"eq_id"`
-	DataType    string            `json:"data_type"`
-	EntityID    []string          `json:"entity_id"`
+	EqVariables    map[string]string `json:"eq_variables"`
+	Score          string            `json:"score"`
+	EqID           int               `json:"eq_id"`
+	DataType       string            `json:"data_type"`
+	EntityID       []string          `json:"entity_id"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 type Payload struct {

--- a/horizon/pkg/configschemaclient/types.go
+++ b/horizon/pkg/configschemaclient/types.go
@@ -30,12 +30,13 @@ type ResponseConfig struct {
 
 // NumerixComponent represents a Numerix/Numerix component
 type NumerixComponent struct {
-	Component    string            `json:"component"`
-	ComponentID  string            `json:"component_id"`
-	ScoreCol     string            `json:"score_col"`
-	ComputeID    string            `json:"compute_id"`
-	ScoreMapping map[string]string `json:"score_mapping"`
-	DataType     string            `json:"data_type"`
+	Component      string            `json:"component"`
+	ComponentID    string            `json:"component_id"`
+	ScoreCol       string            `json:"score_col"`
+	ComputeID      string            `json:"compute_id"`
+	ScoreMapping   map[string]string `json:"score_mapping"`
+	DataType       string            `json:"data_type"`
+	SlateComponent bool              `json:"slate_component"`
 }
 
 // FeatureComponent represents a feature store component
@@ -74,16 +75,17 @@ type SeenScoreComponent struct {
 
 // PredatorComponent represents a Predator model component
 type PredatorComponent struct {
-	Component     string           `json:"component"`
-	ComponentID   string           `json:"component_id"`
-	ModelName     string           `json:"model_name"`
-	ModelEndPoint string           `json:"model_end_point"`
-	Calibration   string           `json:"calibration,omitempty"`
-	Deadline      int              `json:"deadline"`
-	BatchSize     int              `json:"batch_size"`
-	Inputs        []PredatorInput  `json:"inputs"`
-	Outputs       []PredatorOutput `json:"outputs"`
-	RoutingConfig []RoutingConfig  `json:"route_config,omitempty"`
+	Component      string           `json:"component"`
+	ComponentID    string           `json:"component_id"`
+	ModelName      string           `json:"model_name"`
+	ModelEndPoint  string           `json:"model_end_point"`
+	Calibration    string           `json:"calibration,omitempty"`
+	Deadline       int              `json:"deadline"`
+	BatchSize      int              `json:"batch_size"`
+	Inputs         []PredatorInput  `json:"inputs"`
+	Outputs        []PredatorOutput `json:"outputs"`
+	RoutingConfig  []RoutingConfig  `json:"route_config,omitempty"`
+	SlateComponent bool             `json:"slate_component"`
 }
 
 // PredatorInput represents input configuration for Predator

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/CloneInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/CloneInferflowConfigModal.jsx
@@ -508,6 +508,7 @@ const CloneInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => 
         batch_size: '',
         deadline: '110',
         entity_id: [],
+        slate_component: false,
         inputs: [{
           name: '',
           features: [],
@@ -544,7 +545,8 @@ const CloneInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => 
         score: '',
         data_type: 'DataTypeFP32',
         eq_id: '',
-        entity_id: []
+        entity_id: [],
+        slate_component: false
       }]
     }));
     setExpandedReRankers(prev => [...prev, newIndex]);

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/CloneInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/CloneInferflowConfigModal.jsx
@@ -245,7 +245,7 @@ const CloneInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => 
   const fetchMPHosts = async () => {
     try {
       const response = await axios.get(
-        `${URL_CONSTANTS.REACT_APP_HORIZON_BASE_URL}/api/v1/horizon/deployable-discovery/deployables?service_name=InferFlow`,
+        `${URL_CONSTANTS.REACT_APP_HORIZON_BASE_URL}/api/v1/horizon/deployable-discovery/deployables?service_name=inferflow`,
         {
           headers: {
             Authorization: `Bearer ${user?.token}`,
@@ -263,7 +263,7 @@ const CloneInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => 
         setMpHosts([]);
       }
     } catch (error) {
-      console.log('Error fetching InferFlow hosts:', error);
+      console.log('Error fetching inferflow hosts:', error);
       setMpHosts([]);
     }
   };
@@ -719,7 +719,7 @@ const CloneInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => 
 
     // Validate config mapping
     if (!formData.config_mapping.deployable_id) {
-      errors.push('InferFlow Host selection is required');
+      errors.push('inferflow Host selection is required');
     }
 
     // Validate response entity ID (must be at 0th position of response_features)
@@ -824,11 +824,11 @@ const CloneInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => 
         return;
       }
 
-      const successMessage = response.data.data?.message || 'InferFlow Config cloned successfully';
+      const successMessage = response.data.data?.message || 'inferflow Config cloned successfully';
       onSuccess(successMessage);
       onClose();
     } catch (error) {
-      setError(error.response?.data?.error || error.message || 'Failed to clone InferFlow config');
+      setError(error.response?.data?.error || error.message || 'Failed to clone inferflow config');
     } finally {
       setLoading(false);
     }

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/EditInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/EditInferflowConfigModal.jsx
@@ -515,6 +515,7 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
         batch_size: '',
         deadline: '110',
         entity_id: [],
+        slate_component: false,
         inputs: [{
           name: '',
           features: [],
@@ -551,7 +552,8 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
         score: '',
         data_type: 'DataTypeFP32',
         eq_id: '',
-        entity_id: []
+        entity_id: [],
+        slate_component: false
       }]
     }));
     setExpandedReRankers(prev => [...prev, newIndex]);

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/EditInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/EditInferflowConfigModal.jsx
@@ -252,7 +252,7 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
   const fetchMPHosts = async () => {
     try {
       const response = await axios.get(
-        `${URL_CONSTANTS.REACT_APP_HORIZON_BASE_URL}/api/v1/horizon/deployable-discovery/deployables?service_name=InferFlow`,
+        `${URL_CONSTANTS.REACT_APP_HORIZON_BASE_URL}/api/v1/horizon/deployable-discovery/deployables?service_name=inferflow`,
         {
           headers: {
             Authorization: `Bearer ${user?.token}`,
@@ -270,7 +270,7 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
         setMpHosts([]);
       }
     } catch (error) {
-      console.log('Error fetching InferFlow hosts:', error);
+      console.log('Error fetching inferflow hosts:', error);
       setMpHosts([]);
     }
   };
@@ -726,7 +726,7 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
 
     // Validate config mapping
     if (!formData.config_mapping.deployable_id) {
-      errors.push('InferFlow Host selection is required');
+      errors.push('inferflow Host selection is required');
     }
 
     // Validate response entity ID (must be at 0th position of response_features)
@@ -757,7 +757,7 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
       return;
     }
 
-    // Check if InferFlow host has changed
+    // Check if inferflow host has changed
     const originalDeployableId = originalConfig?.config_mapping?.deployable_id || '';
     const currentDeployableId = formData.config_mapping.deployable_id || '';
     
@@ -1060,7 +1060,7 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
           alignItems: 'center'
         }}
       >
-        <Typography variant="h6">Confirm InferFlow Host Change</Typography>
+        <Typography variant="h6">Confirm inferflow Host Change</Typography>
         <IconButton onClick={() => setShowHostChangeConfirmation(false)} size="small" sx={{ color: 'white' }}>
           <CloseIcon />
         </IconButton>
@@ -1068,14 +1068,14 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
       <DialogContent sx={{ mt: 2 }}>
         <Alert severity="warning" sx={{ mb: 3 }}>
           <Typography variant="body2" sx={{ fontWeight: 600 }}>
-            The InferFlow Host has been changed. Please review the details before confirming:
+            The inferflow Host has been changed. Please review the details before confirming:
           </Typography>
         </Alert>
 
         {/* Original Host */}
         <Box sx={{ mb: 3 }}>
           <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, color: '#450839' }}>
-            Previous InferFlow Host:
+            Previous inferflow Host:
           </Typography>
           {(() => {
             const originalDeployableId = originalConfig?.config_mapping?.deployable_id || '';
@@ -1105,7 +1105,7 @@ const EditInferflowConfigModal = ({ open, onClose, onSuccess, configData }) => {
         {/* New Host */}
         <Box sx={{ mb: 2 }}>
           <Typography variant="subtitle2" sx={{ fontWeight: 600, mb: 1, color: '#450839' }}>
-            New InferFlow Host:
+            New inferflow Host:
           </Typography>
           {(() => {
             const currentDeployableId = formData.config_mapping.deployable_id || '';

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/InferflowConfigForm.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/InferflowConfigForm.jsx
@@ -14,6 +14,8 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
+  FormControlLabel,
+  Switch,
 } from '@mui/material';
 import AddIcon from '@mui/icons-material/Add';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -430,6 +432,18 @@ const InferflowConfigForm = ({
                     type="number"
                     value={ranker.deadline}
                     onChange={(e) => handleRankerChange(rankerIndex, 'deadline', e.target.value)}
+                  />
+                </Grid>
+                <Grid item xs={4}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={ranker.slate_component || false}
+                        onChange={(e) => handleRankerChange(rankerIndex, 'slate_component', e.target.checked)}
+                        color="primary"
+                      />
+                    }
+                    label="Slate Component"
                   />
                 </Grid>
               </Grid>
@@ -1060,6 +1074,19 @@ const InferflowConfigForm = ({
                   />
                 </Grid>
                 
+                <Grid item xs={12}>
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={reRanker.slate_component || false}
+                        onChange={(e) => handleReRankerChange(index, 'slate_component', e.target.checked)}
+                        color="secondary"
+                      />
+                    }
+                    label="Slate Component"
+                  />
+                </Grid>
+
                 {/* Entity IDs for re-ranker */}
                 <Grid item xs={12}>
                   <Box sx={{ mt: 2 }}>

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/OnboardInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/OnboardInferflowConfigModal.jsx
@@ -37,6 +37,7 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
       batch_size: '',
       deadline: '110',
       entity_id: [],
+      slate_component: false,
       inputs: [{
         name: '',
         features: [],
@@ -434,6 +435,7 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
         batch_size: '',
         deadline: '110',
         entity_id: [],
+        slate_component: false,
         inputs: [{
           name: '',
           features: [],
@@ -472,7 +474,8 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
         score: '',
         data_type: 'DataTypeFP32',
         eq_id: '',
-        entity_id: []
+        entity_id: [],
+        slate_component: false
       }]
     }));
     // Expand the newly added re-ranker

--- a/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/OnboardInferflowConfigModal.jsx
+++ b/trufflebox-ui/src/pages/InferFlow/DiscoveryRegistry/InferflowRegistry/OnboardInferflowConfigModal.jsx
@@ -175,7 +175,7 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
   const fetchMPHosts = async () => {
     try {
       const response = await axios.get(
-        `${URL_CONSTANTS.REACT_APP_HORIZON_BASE_URL}/api/v1/horizon/deployable-discovery/deployables?service_name=InferFlow`,
+        `${URL_CONSTANTS.REACT_APP_HORIZON_BASE_URL}/api/v1/horizon/deployable-discovery/deployables?service_name=inferflow`,
         {
           headers: {
             Authorization: `Bearer ${user?.token}`,
@@ -193,7 +193,7 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
         setMpHosts([]);
       }
     } catch (error) {
-      console.log('Error fetching InferFlow hosts:', error);
+      console.log('Error fetching inferflow hosts:', error);
       setMpHosts([]);
     }
   };
@@ -652,7 +652,7 @@ const OnboardInferflowConfigModal = ({ open, onClose, onSuccess }) => {
 
     // Validate config mapping
     if (!formData.config_mapping.deployable_id) {
-      errors.push('InferFlow Host selection is required');
+      errors.push('inferflow Host selection is required');
     }
 
     // Validate response entity ID (must be at 0th position of response_features)


### PR DESCRIPTION


## What type of PR is this?
- [x] 🍕 Feature
- [ ] 🐛 Bug Fix
- [ ] ⚙️ Config Change
- [ ] 📝 CHANGELOG/README Update
- [ ] 🎨 Linting
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [ ] 🔁 Version Bump
- [ ] ⏩ Revert


## Description
<!-- description:content -->
### 🔁 Pull Request Template – BharatMLStack


#### Context:
Inferflow already supports a slate_component boolean on PredatorComponentConfig and NumerixComponentConfig that controls whether a component operates at the target level (individual items) or slate level (grouped items). However, Horizon's config onboarding flow had no awareness of this field — it was missing from every layer (UI, API structs, config builder, DB models, etcd models, adaptors, and shared schema client), causing it to always default to false and making it impossible to onboard slate-aware components through Horizon.

#### Describe your changes:
Added the slate_component boolean field across all layers of Horizon's Inferflow config onboarding pipeline, React UI (toggle switches in Onboard, Edit, and Clone modals), handler request structs (Ranker, ReRanker, PredatorComponent, NumerixComponent), config builder (GetPredatorComponents, GetNumerixComponents), SQL DB models, etcd models, all 8 adaptor functions, and the shared configschemaclient types, ensuring the flag is correctly propagated end-to-end from user input to the final etcd config that Inferflow consumes. No DB or etcd migration is needed since configs are stored as JSON and the missing field defaults to false.
- **Horizon (backend)**  
  - **Models:** Added `SlateComponent bool` to `Ranker`, `ReRanker`, `NumerixComponent`, and Predator-related structs in:
    - `horizon/internal/inferflow/handler/models.go`
    - `horizon/internal/inferflow/etcd/models.go`
    - `horizon/internal/repositories/sql/inferflow/models.go`
    - `horizon/pkg/configschemaclient/types.go` (NumerixComponent, PredatorComponent)
  - **Config flow:** Propagate `SlateComponent` in:
    - `horizon/internal/inferflow/handler/adaptor.go` (when mapping to config schema client types)
    - `horizon/internal/inferflow/handler/config_builder.go` (when building config from DB/etcd)
  - Ensures stored config and config served to Inferflow runtime carry the slate-component flag end-to-end.

- **Trufflebox UI (frontend)**  
  - **InferflowConfigForm.jsx:** Added “Slate Component” checkbox for each ranker and each re-ranker; value is bound to `ranker.slate_component` and `reRanker.slate_component` and included in submit payloads.
  - **OnboardInferflowConfigModal.jsx, EditInferflowConfigModal.jsx, CloneInferflowConfigModal.jsx:** Default and map `slate_component: false` for rankers and re-rankers when initializing or transforming payloads so existing flows remain unchanged and new configs can opt in to slate component.

#### Checklist before requesting a review
- [x] I have reviewed my own changes?
- [ ] Relevant or critical functionality is covered by tests?
- [ ] Monitoring needs have been evaluated?
- [ ] Any necessary documentation updates have been considered?

#### 📂 Modules Affected
<!-- Tick all that apply -->
- [x] `horizon` (Real-time systems / networking)
- [ ] `online-feature-store` (Feature serving infra)
- [x] `trufflebox-ui` (Admin panel / UI)
- [ ] `infra` (Docker, CI/CD, GCP/AWS setup)
- [ ] `docs` (Documentation updates)
- [ ] Other: `___________`

---

#### ✅ Type of Change

- [x] Feature addition
- [ ] Bug fix
- [ ] Infra / build system change
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Other: `___________`

---

#### 📊 Benchmark / Metrics (if applicable)
<!-- /description:content -->


## Key Requirement Doc
<!-- krd:pod-type -->
Pod Type:
- [x] H0
- [ ] H1
- [ ] H2
<!-- /krd:pod-type -->

<!-- krd:justification -->
**Why KRD is not required?**
KRD is not required for this change
<!-- /krd:justification -->


### Added Tests
- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help

#### If yes, what is the strategy?
- [ ]  Manual
- [ ]  Unit Tests
- [ ]  API/Integration Tests

<!-- ReadyToReview Start -->
> _Updated by ReadyToReviewBot for @paras-agarwal-meesho_
<!-- ReadyToReview End -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Slate Component toggle controls to InferFlow configuration forms, enabling users to configure slate-based rendering for rankers and re-rankers in deployments.

* **Updates**
  * Standardized service naming to lowercase "inferflow" across all UI elements and API communications for improved consistency.
  * New rankers and re-rankers are automatically initialized with Slate Component disabled by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->