### PR TITLE
fix(py-sdk): lowercase gRPC metadata headers for Python compatibility

### DIFF
--- a/py-sdk/grpc_feature_client/grpc_feature_client/client.py
+++ b/py-sdk/grpc_feature_client/grpc_feature_client/client.py
@@ -19,9 +19,10 @@ from .config import GRPCClientConfig
 # Set up logging
 logger = logging.getLogger(__name__)
 
-# gRPC authentication headers (from Go SDK)
-HEADER_CALLER_ID = "ONLINE-FEATURE-STORE-CALLER-ID"
-HEADER_CALLER_TOKEN = "ONLINE-FEATURE-STORE-AUTH-TOKEN"
+# gRPC authentication headers (lowercase per HTTP/2 spec, matching Go server middleware)
+# Python grpcio rejects non-lowercase metadata keys unlike Go grpc which auto-lowercases
+HEADER_CALLER_ID = "online-feature-store-caller-id"
+HEADER_CALLER_TOKEN = "online-feature-store-auth-token"
 
 try:
     import grpc


### PR DESCRIPTION
# 🔁 Pull Request Template – BharatMLStack

## Context:
Python gRPC clients fail with `metadata was invalid` when calling the online-feature-store service because the `py-sdk` defines metadata header keys in uppercase. HTTP/2 (RFC 7540 §8.1.2) requires header field names to be lowercase. The Go SDK works because `grpc-go` auto-lowercases metadata keys, but Python's `grpcio` enforces the spec strictly and rejects them.

Fixes #165.

## Describe your changes:
Lowercased `HEADER_CALLER_ID` and `HEADER_CALLER_TOKEN` in `py-sdk/grpc_feature_client/grpc_feature_client/client.py`:

```python
# Before
HEADER_CALLER_ID    = "ONLINE-FEATURE-STORE-CALLER-ID"
HEADER_CALLER_TOKEN = "ONLINE-FEATURE-STORE-AUTH-TOKEN"

# After
HEADER_CALLER_ID    = "online-feature-store-caller-id"
HEADER_CALLER_TOKEN = "online-feature-store-auth-token"
```

These now match the server-side constants in `online-feature-store/internal/server/grpc/middleware.go`, which the Go SDK was already sending in lowercase form (via grpc-go's auto-normalization).

## Testing:
**Manual:**
1. Built the `py-sdk` locally with the patch.
2. Pointed it at a local `online-feature-store` instance.
3. Confirmed that a `GetFeatures` call now succeeds; without the fix it returns `metadata was invalid`.

**Existing automated tests:** the constants are only consumed by the gRPC client header builder, which is exercised by every integration call. No new unit test added — verifying a 2-line constant change is best done at the wire/metadata level which the existing call paths cover.

## Monitoring:
No new instrumentation required. Failures previously surfaced as `metadata was invalid` errors in gRPC client logs; after the fix those errors should no longer occur for Python callers. Existing gRPC server-side metrics for request count / error rate already cover regression detection.

## Rollback plan
Single-file, two-line constant change. To revert: `git revert <commit-sha>` on the merge commit, or change the two constants back to uppercase. No data migrations, no schema changes, no config rollout. Rollback is instant on the next SDK release.

## Checklist before requesting a review
- [x] I have reviewed my own changes
- [x] Relevant or critical functionality is covered by tests
- [x] Monitoring needs have been evaluated
- [x] Any necessary documentation updates have been considered

## 📂 Modules Affected
<!-- Tick all that apply -->
- [ ] `horizon` (Real-time systems / networking)
- [ ] `online-feature-store` (Feature serving infra)
- [ ] `trufflebox-ui` (Admin panel / UI)
- [ ] `infra` (Docker, CI/CD, GCP/AWS setup)
- [ ] `docs` (Documentation updates)
- [x] Other: `py-sdk` (Python gRPC client)

---

## ✅ Type of Change

- [ ] Feature addition
- [x] Bug fix
- [ ] Infra / build system change
- [ ] Performance improvement
- [ ] Refactor
- [ ] Documentation
- [ ] Other: `___________`

---

## 📊 Benchmark / Metrics (if applicable)
N/A — constant value change only, no perf impact.
