### PR TITLE
fix(py-sdk): lowercase gRPC metadata header keys

### DIFF
--- a/py-sdk/grpc_feature_client/grpc_feature_client/client.py
+++ b/py-sdk/grpc_feature_client/grpc_feature_client/client.py
@@ -19,9 +19,11 @@ from .config import GRPCClientConfig
 # Set up logging
 logger = logging.getLogger(__name__)
 
-# gRPC authentication headers (from Go SDK)
-HEADER_CALLER_ID = "ONLINE-FEATURE-STORE-CALLER-ID"
-HEADER_CALLER_TOKEN = "ONLINE-FEATURE-STORE-AUTH-TOKEN"
+# gRPC authentication headers (must be lowercase; grpcio validates metadata
+# keys against HTTP/2's ASCII-lowercase requirement and rejects uppercase
+# keys with `Illegal header key` before the call ever leaves the client).
+HEADER_CALLER_ID = "online-feature-store-caller-id"
+HEADER_CALLER_TOKEN = "online-feature-store-auth-token"
 
 try:
     import grpc


### PR DESCRIPTION
## Summary
Fixes #165 — \`GRPCFeatureClient\` cannot send a single request from Python because grpcio rejects the uppercase metadata keys at client-side validation.

## Problem
\`py-sdk/grpc_feature_client/grpc_feature_client/client.py\` declares:
\`\`\`python
HEADER_CALLER_ID = \"ONLINE-FEATURE-STORE-CALLER-ID\"
HEADER_CALLER_TOKEN = \"ONLINE-FEATURE-STORE-AUTH-TOKEN\"
\`\`\`

When these are passed to \`.with_call(metadata=...)\`, grpcio's \`validate_metadata\` checks each key against HTTP/2's grammar — ASCII-lowercase only — and fails with:

\`\`\`
INTERNAL: Illegal header key
\`\`\`

The call never leaves the Python process.

## Fix
Rename both constants to lowercase:
\`\`\`python
HEADER_CALLER_ID = \"online-feature-store-caller-id\"
HEADER_CALLER_TOKEN = \"online-feature-store-auth-token\"
\`\`\`

## Server compatibility
The server reads these via \`metadata.FromIncomingContext(ctx)\` + \`md.Get(key)\` ([go-sdk/pkg/api/request_context.go:42-117](https://github.com/Meesho/BharatMLStack/blob/main/go-sdk/pkg/api/request_context.go#L42)). \`metadata.MD.Get\` is **case-insensitive** (grpc-go lowercases on lookup), so the server accepts both cases. The existing Go SDK (\`go-sdk/pkg/onfs/client.go:18-19\`) still declares uppercase constants — grpc-go silently normalizes them to lowercase on the wire, so there's no wire-level divergence between the two clients.

No changes needed on the Go side. The Go constants can be lowercased in a separate cleanup PR if you want consistency, but it isn't required for this fix.

## Test plan
- [x] Python SDK builds a unary call with valid metadata (no more \`Illegal header key\`).
- [x] Server-side auth middleware still resolves the caller ID / token.
- [x] Existing Go SDK continues to work unchanged (headers are lowercased by grpc-go on send).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gRPC authentication metadata headers to use lowercase naming conventions, ensuring proper communication and compatibility with gRPC services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->