### PR TITLE
fix(auth): rate-limit and lock out brute-force login attempts

### DIFF
--- a/horizon/go.mod
+++ b/horizon/go.mod
@@ -27,6 +27,7 @@ require (
 	golang.org/x/crypto v0.44.0
 	golang.org/x/exp v0.0.0-20251125195548-87e1e737ad39
 	golang.org/x/oauth2 v0.33.0
+	golang.org/x/time v0.14.0
 	google.golang.org/api v0.256.0
 	google.golang.org/grpc v1.76.0
 	google.golang.org/protobuf v1.36.10
@@ -131,7 +132,6 @@ require (
 	golang.org/x/sync v0.18.0 // indirect
 	golang.org/x/sys v0.38.0 // indirect
 	golang.org/x/text v0.31.0 // indirect
-	golang.org/x/time v0.14.0 // indirect
 	golang.org/x/tools v0.39.0 // indirect
 	google.golang.org/genproto v0.0.0-20250715232539-7130f93afb79 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250818200422-3122310a409c // indirect

--- a/horizon/internal/auth/handler/auth.go
+++ b/horizon/internal/auth/handler/auth.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/Meesho/BharatMLStack/horizon/internal/repositories/sql/auth"
@@ -14,6 +15,28 @@ import (
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/bcrypt"
 )
+
+const (
+	// maxLoginFailures is the number of consecutive failed logins for a single
+	// account before it is temporarily locked.
+	maxLoginFailures = 5
+	// loginLockDuration is how long an account stays locked after hitting the
+	// failure threshold.
+	loginLockDuration = 15 * time.Minute
+)
+
+// loginLockState tracks consecutive login failures for an account.
+//
+// NOTE: this is in-memory and therefore per-replica. For a multi-replica
+// deployment move this counter to a shared store (Redis/DB) so the lockout is
+// enforced globally. It is still a useful defence-in-depth layer alongside the
+// per-IP rate limiter on the /login route.
+type loginLockState struct {
+	failures int
+	until    time.Time
+}
+
+var loginFailures sync.Map // email -> *loginLockState
 
 type AuthHandler struct {
 	authRepo       auth.Repository
@@ -136,9 +159,16 @@ func (a *AuthHandler) Register(user *User) error {
 
 // Login method
 func (a *AuthHandler) Login(user *Login) (*LoginResponse, error) {
+	// Enforce per-account lockout before doing any expensive work.
+	if locked, retryAfter := isAccountLocked(user.Email); locked {
+		log.Warn().Msgf("Login blocked for %s: account temporarily locked", user.Email)
+		return nil, fmt.Errorf("account temporarily locked due to too many failed attempts, try again in %s", retryAfter.Round(time.Second))
+	}
+
 	// Fetch user from the repository using email
 	authUser, err := a.authRepo.GetUserByEmailId(user.Email)
 	if err != nil {
+		recordLoginFailure(user.Email)
 		log.Error().Msgf("User not found with email: %s", user.Email)
 		return nil, fmt.Errorf("invalid email or password")
 	}
@@ -146,6 +176,7 @@ func (a *AuthHandler) Login(user *Login) (*LoginResponse, error) {
 	// Compare the provided password with the stored password hash
 	err = bcrypt.CompareHashAndPassword([]byte(authUser.PasswordHash), []byte(user.Password))
 	if err != nil {
+		recordLoginFailure(user.Email)
 		log.Error().Msg("Password mismatch")
 		return nil, fmt.Errorf("invalid email or password")
 	}
@@ -153,6 +184,9 @@ func (a *AuthHandler) Login(user *Login) (*LoginResponse, error) {
 		log.Error().Msgf("User %s is not active, Please contact admin to activate your account", authUser.Email)
 		return nil, fmt.Errorf("User is not active, Please contact admin to activate your account")
 	}
+
+	// Successful authentication resets the failure counter.
+	resetLoginFailures(user.Email)
 
 	// Generate JWT token
 	expirationTime := time.Now().Add(24 * time.Hour)
@@ -189,6 +223,37 @@ func (a *AuthHandler) Logout(token string) error {
 		return err
 	}
 	return err
+}
+
+// isAccountLocked reports whether the account is currently locked out and, if
+// so, how long until it is unlocked.
+func isAccountLocked(email string) (bool, time.Duration) {
+	v, ok := loginFailures.Load(email)
+	if !ok {
+		return false, 0
+	}
+	st := v.(*loginLockState)
+	if st.until.IsZero() || time.Now().After(st.until) {
+		return false, 0
+	}
+	return true, time.Until(st.until)
+}
+
+// recordLoginFailure increments the failure counter for the account and locks
+// it once the threshold is reached.
+func recordLoginFailure(email string) {
+	v, _ := loginFailures.LoadOrStore(email, &loginLockState{})
+	st := v.(*loginLockState)
+	st.failures++
+	if st.failures >= maxLoginFailures {
+		st.until = time.Now().Add(loginLockDuration)
+		st.failures = 0
+	}
+}
+
+// resetLoginFailures clears any failure/lock state for the account.
+func resetLoginFailures(email string) {
+	loginFailures.Delete(email)
 }
 
 func (a *AuthHandler) saveToken(email, token string, expiration time.Time) error {

--- a/horizon/internal/auth/handler/auth.go
+++ b/horizon/internal/auth/handler/auth.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 	"github.com/rs/zerolog/log"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 )
 
 const (
@@ -23,6 +25,11 @@ const (
 	// loginLockDuration is how long an account stays locked after hitting the
 	// failure threshold.
 	loginLockDuration = 15 * time.Minute
+	// loginFailureRetention bounds how long an idle failure-tracking entry is
+	// kept. Entries not touched within this window are evicted so that an
+	// attacker spraying many distinct (often non-existent) emails cannot grow
+	// the in-memory map without bound.
+	loginFailureRetention = loginLockDuration
 )
 
 // loginLockState tracks consecutive login failures for an account.
@@ -31,12 +38,21 @@ const (
 // deployment move this counter to a shared store (Redis/DB) so the lockout is
 // enforced globally. It is still a useful defence-in-depth layer alongside the
 // per-IP rate limiter on the /login route.
+//
+// All fields are guarded by the package-level loginFailuresMu. They are read
+// and written from concurrent request goroutines, so the mutex is required to
+// avoid a data race.
 type loginLockState struct {
 	failures int
 	until    time.Time
+	// updatedAt is the last time this entry was modified; used for eviction.
+	updatedAt time.Time
 }
 
-var loginFailures sync.Map // email -> *loginLockState
+var (
+	loginFailuresMu sync.Mutex
+	loginFailures   = make(map[string]*loginLockState) // email -> state
+)
 
 type AuthHandler struct {
 	authRepo       auth.Repository
@@ -162,15 +178,29 @@ func (a *AuthHandler) Login(user *Login) (*LoginResponse, error) {
 	// Enforce per-account lockout before doing any expensive work.
 	if locked, retryAfter := isAccountLocked(user.Email); locked {
 		log.Warn().Msgf("Login blocked for %s: account temporarily locked", user.Email)
-		return nil, fmt.Errorf("account temporarily locked due to too many failed attempts, try again in %s", retryAfter.Round(time.Second))
+		// Round up to whole seconds so a sub-second remainder is never reported
+		// as "0s" (which would be a confusing instruction to the user).
+		wait := retryAfter.Round(time.Second)
+		if wait < time.Second {
+			wait = time.Second
+		}
+		return nil, fmt.Errorf("account temporarily locked due to too many failed attempts, try again in %s", wait)
 	}
 
 	// Fetch user from the repository using email
 	authUser, err := a.authRepo.GetUserByEmailId(user.Email)
 	if err != nil {
-		recordLoginFailure(user.Email)
-		log.Error().Msgf("User not found with email: %s", user.Email)
-		return nil, fmt.Errorf("invalid email or password")
+		// Only count *authentication* failures (no such user) toward the
+		// lockout. A transient backend error (DB down, timeout, etc.) is not an
+		// attacker's failed guess, so locking on it would let infra blips lock
+		// out legitimate users and would surface as a confusing error.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			recordLoginFailure(user.Email)
+			log.Error().Msgf("User not found with email: %s", user.Email)
+			return nil, fmt.Errorf("invalid email or password")
+		}
+		log.Error().Err(err).Msgf("Error looking up user %s", user.Email)
+		return nil, fmt.Errorf("login temporarily unavailable, please try again")
 	}
 
 	// Compare the provided password with the stored password hash
@@ -228,11 +258,13 @@ func (a *AuthHandler) Logout(token string) error {
 // isAccountLocked reports whether the account is currently locked out and, if
 // so, how long until it is unlocked.
 func isAccountLocked(email string) (bool, time.Duration) {
-	v, ok := loginFailures.Load(email)
+	loginFailuresMu.Lock()
+	defer loginFailuresMu.Unlock()
+
+	st, ok := loginFailures[email]
 	if !ok {
 		return false, 0
 	}
-	st := v.(*loginLockState)
 	if st.until.IsZero() || time.Now().After(st.until) {
 		return false, 0
 	}
@@ -241,10 +273,25 @@ func isAccountLocked(email string) (bool, time.Duration) {
 
 // recordLoginFailure increments the failure counter for the account and locks
 // it once the threshold is reached.
+//
+// Unknown/non-existent emails are recorded exactly like real ones. This is
+// deliberate: the lockout check short-circuits before the user lookup, so a
+// known and an unknown email that cross the threshold produce the identical
+// "locked" response. Recording both keeps that behaviour symmetric and avoids
+// turning the lockout into an account-existence oracle.
 func recordLoginFailure(email string) {
-	v, _ := loginFailures.LoadOrStore(email, &loginLockState{})
-	st := v.(*loginLockState)
+	loginFailuresMu.Lock()
+	defer loginFailuresMu.Unlock()
+
+	evictExpiredLocked()
+
+	st, ok := loginFailures[email]
+	if !ok {
+		st = &loginLockState{}
+		loginFailures[email] = st
+	}
 	st.failures++
+	st.updatedAt = time.Now()
 	if st.failures >= maxLoginFailures {
 		st.until = time.Now().Add(loginLockDuration)
 		st.failures = 0
@@ -253,7 +300,26 @@ func recordLoginFailure(email string) {
 
 // resetLoginFailures clears any failure/lock state for the account.
 func resetLoginFailures(email string) {
-	loginFailures.Delete(email)
+	loginFailuresMu.Lock()
+	defer loginFailuresMu.Unlock()
+	delete(loginFailures, email)
+}
+
+// evictExpiredLocked removes stale entries to bound memory growth from an
+// attacker spraying many distinct emails. An entry is safe to drop once it is
+// not actively locked and has not been touched within the retention window.
+// Caller must hold loginFailuresMu.
+func evictExpiredLocked() {
+	now := time.Now()
+	for email, st := range loginFailures {
+		locked := !st.until.IsZero() && now.Before(st.until)
+		if locked {
+			continue
+		}
+		if now.Sub(st.updatedAt) >= loginFailureRetention {
+			delete(loginFailures, email)
+		}
+	}
 }
 
 func (a *AuthHandler) saveToken(email, token string, expiration time.Time) error {

--- a/horizon/internal/auth/handler/auth_lockout_test.go
+++ b/horizon/internal/auth/handler/auth_lockout_test.go
@@ -1,0 +1,97 @@
+package handler
+
+import (
+	"testing"
+	"time"
+
+	"github.com/Meesho/BharatMLStack/horizon/internal/repositories/sql/auth"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// fakeAuthRepo is a minimal auth.Repository for exercising Login.
+type fakeAuthRepo struct {
+	user *auth.User
+}
+
+func (f *fakeAuthRepo) GetAllUsers() ([]auth.User, error) { return nil, nil }
+func (f *fakeAuthRepo) GetUserByID(id uint) (*auth.User, error) {
+	return nil, nil
+}
+func (f *fakeAuthRepo) GetUserByEmailId(emailId string) (*auth.User, error) {
+	if f.user != nil && f.user.Email == emailId {
+		return f.user, nil
+	}
+	return nil, errGorm
+}
+func (f *fakeAuthRepo) CreateUser(user *auth.User) (uint, error)                     { return 1, nil }
+func (f *fakeAuthRepo) UpdateUser(user *auth.User) error                             { return nil }
+func (f *fakeAuthRepo) DeleteUser(id uint) error                                     { return nil }
+func (f *fakeAuthRepo) UpdateUserAccessAndRole(email string, a bool, r string) error { return nil }
+
+// fakeTokenRepo is a no-op token.Repository.
+type fakeTokenRepo struct{}
+
+func (fakeTokenRepo) SaveToken(email, token string, expiration time.Time) error { return nil }
+func (fakeTokenRepo) InvalidateToken(token string) error                        { return nil }
+func (fakeTokenRepo) IsTokenValid(token string) (bool, error)                   { return true, nil }
+func (fakeTokenRepo) CleanupExpiredTokens() error                               { return nil }
+
+var errGorm = errorString("record not found")
+
+type errorString string
+
+func (e errorString) Error() string { return string(e) }
+
+func newTestHandler(u *auth.User) *AuthHandler {
+	return &AuthHandler{authRepo: &fakeAuthRepo{user: u}, tokenRepo: fakeTokenRepo{}}
+}
+
+func TestLogin_LocksAfterRepeatedFailures(t *testing.T) {
+	email := "lockme@example.com"
+	loginFailures.Delete(email) // isolate from other tests
+
+	hash, _ := bcrypt.GenerateFromPassword([]byte("CorrectHorse1!"), bcrypt.DefaultCost)
+	h := newTestHandler(&auth.User{Email: email, PasswordHash: string(hash), IsActive: true})
+
+	// Hit the wrong password maxLoginFailures times.
+	for i := 0; i < maxLoginFailures; i++ {
+		if _, err := h.Login(&Login{Email: email, Password: "wrong"}); err == nil {
+			t.Fatalf("attempt %d: expected error for wrong password", i+1)
+		}
+	}
+
+	// Now the account should be locked even with the *correct* password.
+	if _, err := h.Login(&Login{Email: email, Password: "CorrectHorse1!"}); err == nil {
+		t.Fatal("expected account to be locked after repeated failures")
+	}
+
+	loginFailures.Delete(email) // cleanup
+}
+
+func TestLogin_SuccessResetsFailureCounter(t *testing.T) {
+	email := "resetme@example.com"
+	loginFailures.Delete(email)
+
+	hash, _ := bcrypt.GenerateFromPassword([]byte("CorrectHorse1!"), bcrypt.DefaultCost)
+	h := newTestHandler(&auth.User{Email: email, PasswordHash: string(hash), IsActive: true})
+
+	// A few failures, but below the threshold.
+	for i := 0; i < maxLoginFailures-1; i++ {
+		_, _ = h.Login(&Login{Email: email, Password: "wrong"})
+	}
+	// A successful login should clear the counter.
+	if _, err := h.Login(&Login{Email: email, Password: "CorrectHorse1!"}); err != nil {
+		t.Fatalf("expected successful login, got %v", err)
+	}
+	if locked, _ := isAccountLocked(email); locked {
+		t.Fatal("account should not be locked after a successful login")
+	}
+
+	loginFailures.Delete(email)
+}
+
+func TestIsAccountLocked_Unknown(t *testing.T) {
+	if locked, _ := isAccountLocked("never-seen@example.com"); locked {
+		t.Fatal("unknown account should not be locked")
+	}
+}

--- a/horizon/internal/auth/handler/auth_lockout_test.go
+++ b/horizon/internal/auth/handler/auth_lockout_test.go
@@ -1,16 +1,21 @@
 package handler
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/Meesho/BharatMLStack/horizon/internal/repositories/sql/auth"
 	"golang.org/x/crypto/bcrypt"
+	"gorm.io/gorm"
 )
 
-// fakeAuthRepo is a minimal auth.Repository for exercising Login.
+// fakeAuthRepo is a minimal auth.Repository for exercising Login. It returns
+// the configured user for a matching email, gorm.ErrRecordNotFound for any
+// other email, and a configurable transient error when lookupErr is set.
 type fakeAuthRepo struct {
-	user *auth.User
+	user      *auth.User
+	lookupErr error
 }
 
 func (f *fakeAuthRepo) GetAllUsers() ([]auth.User, error) { return nil, nil }
@@ -18,10 +23,13 @@ func (f *fakeAuthRepo) GetUserByID(id uint) (*auth.User, error) {
 	return nil, nil
 }
 func (f *fakeAuthRepo) GetUserByEmailId(emailId string) (*auth.User, error) {
+	if f.lookupErr != nil {
+		return nil, f.lookupErr
+	}
 	if f.user != nil && f.user.Email == emailId {
 		return f.user, nil
 	}
-	return nil, errGorm
+	return nil, gorm.ErrRecordNotFound
 }
 func (f *fakeAuthRepo) CreateUser(user *auth.User) (uint, error)                     { return 1, nil }
 func (f *fakeAuthRepo) UpdateUser(user *auth.User) error                             { return nil }
@@ -36,19 +44,13 @@ func (fakeTokenRepo) InvalidateToken(token string) error                        
 func (fakeTokenRepo) IsTokenValid(token string) (bool, error)                   { return true, nil }
 func (fakeTokenRepo) CleanupExpiredTokens() error                               { return nil }
 
-var errGorm = errorString("record not found")
-
-type errorString string
-
-func (e errorString) Error() string { return string(e) }
-
 func newTestHandler(u *auth.User) *AuthHandler {
 	return &AuthHandler{authRepo: &fakeAuthRepo{user: u}, tokenRepo: fakeTokenRepo{}}
 }
 
 func TestLogin_LocksAfterRepeatedFailures(t *testing.T) {
 	email := "lockme@example.com"
-	loginFailures.Delete(email) // isolate from other tests
+	resetLoginFailures(email) // isolate from other tests
 
 	hash, _ := bcrypt.GenerateFromPassword([]byte("CorrectHorse1!"), bcrypt.DefaultCost)
 	h := newTestHandler(&auth.User{Email: email, PasswordHash: string(hash), IsActive: true})
@@ -65,12 +67,12 @@ func TestLogin_LocksAfterRepeatedFailures(t *testing.T) {
 		t.Fatal("expected account to be locked after repeated failures")
 	}
 
-	loginFailures.Delete(email) // cleanup
+	resetLoginFailures(email) // cleanup
 }
 
 func TestLogin_SuccessResetsFailureCounter(t *testing.T) {
 	email := "resetme@example.com"
-	loginFailures.Delete(email)
+	resetLoginFailures(email)
 
 	hash, _ := bcrypt.GenerateFromPassword([]byte("CorrectHorse1!"), bcrypt.DefaultCost)
 	h := newTestHandler(&auth.User{Email: email, PasswordHash: string(hash), IsActive: true})
@@ -87,11 +89,60 @@ func TestLogin_SuccessResetsFailureCounter(t *testing.T) {
 		t.Fatal("account should not be locked after a successful login")
 	}
 
-	loginFailures.Delete(email)
+	resetLoginFailures(email)
 }
 
 func TestIsAccountLocked_Unknown(t *testing.T) {
 	if locked, _ := isAccountLocked("never-seen@example.com"); locked {
 		t.Fatal("unknown account should not be locked")
 	}
+}
+
+// TestLogin_UnknownEmailLocksLikeKnown verifies that an email with no backing
+// account still locks after the threshold and reports the *same* generic
+// "locked" error a known account would. This keeps the lockout from becoming an
+// account-existence oracle.
+func TestLogin_UnknownEmailLocksLikeKnown(t *testing.T) {
+	email := "ghost@example.com"
+	resetLoginFailures(email)
+
+	h := newTestHandler(nil) // no user exists; lookups return ErrRecordNotFound
+
+	for i := 0; i < maxLoginFailures; i++ {
+		if _, err := h.Login(&Login{Email: email, Password: "whatever"}); err == nil {
+			t.Fatalf("attempt %d: expected error for unknown email", i+1)
+		}
+	}
+
+	locked, _ := isAccountLocked(email)
+	if !locked {
+		t.Fatal("unknown email should be locked after crossing the threshold")
+	}
+
+	resetLoginFailures(email)
+}
+
+// TestLogin_TransientErrorDoesNotLock verifies that a transient backend error
+// (anything other than ErrRecordNotFound) is not counted as a failed login, so
+// an infra blip cannot lock out a legitimate user.
+func TestLogin_TransientErrorDoesNotLock(t *testing.T) {
+	email := "flaky-db@example.com"
+	resetLoginFailures(email)
+
+	h := &AuthHandler{
+		authRepo:  &fakeAuthRepo{lookupErr: errors.New("connection refused")},
+		tokenRepo: fakeTokenRepo{},
+	}
+
+	for i := 0; i < maxLoginFailures+2; i++ {
+		if _, err := h.Login(&Login{Email: email, Password: "whatever"}); err == nil {
+			t.Fatalf("attempt %d: expected transient error", i+1)
+		}
+	}
+
+	if locked, _ := isAccountLocked(email); locked {
+		t.Fatal("account must not be locked due to transient backend errors")
+	}
+
+	resetLoginFailures(email)
 }

--- a/horizon/internal/auth/router/router.go
+++ b/horizon/internal/auth/router/router.go
@@ -1,17 +1,26 @@
 package router
 
 import (
+	"time"
+
 	"github.com/Meesho/BharatMLStack/horizon/internal/auth/controller"
+	"github.com/Meesho/BharatMLStack/horizon/internal/middleware"
 	"github.com/Meesho/BharatMLStack/horizon/pkg/httpframework"
 	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
 )
+
+// loginRateLimiter throttles login attempts per client IP to slow down
+// brute-force / credential-stuffing attacks. Allows ~5 attempts per minute
+// with a small burst; idle IP entries are evicted after 10 minutes.
+var loginRateLimiter = middleware.NewIPRateLimiter(rate.Every(12*time.Second), 5, 10*time.Minute)
 
 // Init expects http framework to be initialized before calling this function
 func Init() {
 	api := httpframework.Instance().Group("/")
 	{
 		api.POST("/register", controller.NewController().Register)
-		api.POST("/login", controller.NewController().Login)
+		api.POST("/login", loginRateLimiter.Middleware(), controller.NewController().Login)
 		api.POST("/logout", controller.NewController().Logout)
 		api.GET("/users", controller.NewController().GetAllUsers)
 		api.PUT("/update-user", controller.NewController().UpdateUserAccessAndRole)

--- a/horizon/internal/middleware/ratelimit.go
+++ b/horizon/internal/middleware/ratelimit.go
@@ -18,6 +18,7 @@ type IPRateLimiter struct {
 	r       rate.Limit
 	burst   int
 	ttl     time.Duration
+	stop    chan struct{}
 }
 
 type clientLimiter struct {
@@ -26,29 +27,46 @@ type clientLimiter struct {
 }
 
 // NewIPRateLimiter creates a limiter allowing r events/second with the given
-// burst. Idle per-IP entries are evicted after ttl to bound memory usage.
+// burst. Idle per-IP entries are evicted after ttl to bound memory usage. A
+// non-positive ttl disables the background eviction loop (entries then live for
+// the lifetime of the limiter), which keeps time.NewTicker from panicking.
 func NewIPRateLimiter(r rate.Limit, burst int, ttl time.Duration) *IPRateLimiter {
 	l := &IPRateLimiter{
 		clients: make(map[string]*clientLimiter),
 		r:       r,
 		burst:   burst,
 		ttl:     ttl,
+		stop:    make(chan struct{}),
 	}
-	go l.cleanupLoop()
+	if ttl > 0 {
+		go l.cleanupLoop()
+	}
 	return l
+}
+
+// Stop terminates the background eviction goroutine. It is safe to call once;
+// calling it more than once will panic (close of closed channel), matching the
+// usual lifecycle expectation for a long-lived limiter.
+func (l *IPRateLimiter) Stop() {
+	close(l.stop)
 }
 
 func (l *IPRateLimiter) cleanupLoop() {
 	ticker := time.NewTicker(l.ttl)
 	defer ticker.Stop()
-	for range ticker.C {
-		l.mu.Lock()
-		for ip, cl := range l.clients {
-			if time.Since(cl.lastSeen) > l.ttl {
-				delete(l.clients, ip)
+	for {
+		select {
+		case <-l.stop:
+			return
+		case <-ticker.C:
+			l.mu.Lock()
+			for ip, cl := range l.clients {
+				if time.Since(cl.lastSeen) > l.ttl {
+					delete(l.clients, ip)
+				}
 			}
+			l.mu.Unlock()
 		}
-		l.mu.Unlock()
 	}
 }
 

--- a/horizon/internal/middleware/ratelimit.go
+++ b/horizon/internal/middleware/ratelimit.go
@@ -1,0 +1,86 @@
+package middleware
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+// IPRateLimiter applies a token-bucket rate limit per client IP. It is intended
+// for sensitive, unauthenticated endpoints such as /login where an attacker
+// could otherwise attempt unlimited credential guesses.
+type IPRateLimiter struct {
+	mu      sync.Mutex
+	clients map[string]*clientLimiter
+	r       rate.Limit
+	burst   int
+	ttl     time.Duration
+}
+
+type clientLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// NewIPRateLimiter creates a limiter allowing r events/second with the given
+// burst. Idle per-IP entries are evicted after ttl to bound memory usage.
+func NewIPRateLimiter(r rate.Limit, burst int, ttl time.Duration) *IPRateLimiter {
+	l := &IPRateLimiter{
+		clients: make(map[string]*clientLimiter),
+		r:       r,
+		burst:   burst,
+		ttl:     ttl,
+	}
+	go l.cleanupLoop()
+	return l
+}
+
+func (l *IPRateLimiter) cleanupLoop() {
+	ticker := time.NewTicker(l.ttl)
+	defer ticker.Stop()
+	for range ticker.C {
+		l.mu.Lock()
+		for ip, cl := range l.clients {
+			if time.Since(cl.lastSeen) > l.ttl {
+				delete(l.clients, ip)
+			}
+		}
+		l.mu.Unlock()
+	}
+}
+
+func (l *IPRateLimiter) get(ip string) *rate.Limiter {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	cl, ok := l.clients[ip]
+	if !ok {
+		cl = &clientLimiter{limiter: rate.NewLimiter(l.r, l.burst)}
+		l.clients[ip] = cl
+	}
+	cl.lastSeen = time.Now()
+	return cl.limiter
+}
+
+// Allow reports whether a request from ip may proceed.
+func (l *IPRateLimiter) Allow(ip string) bool {
+	return l.get(ip).Allow()
+}
+
+// Middleware returns a gin handler that rejects requests exceeding the limit
+// with HTTP 429. NOTE: behind a proxy/ingress, configure gin's TrustedProxies
+// so that ClientIP() reflects the real client and cannot be spoofed via
+// X-Forwarded-For.
+func (l *IPRateLimiter) Middleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !l.Allow(c.ClientIP()) {
+			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{
+				"error": "too many requests, please try again later",
+			})
+			return
+		}
+		c.Next()
+	}
+}

--- a/horizon/internal/middleware/ratelimit_test.go
+++ b/horizon/internal/middleware/ratelimit_test.go
@@ -1,0 +1,54 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"golang.org/x/time/rate"
+)
+
+func TestIPRateLimiter_Allow(t *testing.T) {
+	// 1 event/sec, burst of 2: the first 2 calls pass, the 3rd is blocked.
+	l := NewIPRateLimiter(rate.Every(time.Second), 2, time.Minute)
+
+	if !l.Allow("1.2.3.4") {
+		t.Fatal("call 1 should be allowed")
+	}
+	if !l.Allow("1.2.3.4") {
+		t.Fatal("call 2 (within burst) should be allowed")
+	}
+	if l.Allow("1.2.3.4") {
+		t.Fatal("call 3 should be rate limited")
+	}
+	// A different IP has its own independent bucket.
+	if !l.Allow("5.6.7.8") {
+		t.Fatal("different IP should have its own bucket")
+	}
+}
+
+func TestIPRateLimiter_Middleware(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	l := NewIPRateLimiter(rate.Every(time.Hour), 1, time.Minute) // burst 1
+	r := gin.New()
+	r.POST("/login", l.Middleware(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	do := func() int {
+		req := httptest.NewRequest(http.MethodPost, "/login", nil)
+		req.RemoteAddr = "9.9.9.9:1234"
+		w := httptest.NewRecorder()
+		r.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	if code := do(); code != http.StatusOK {
+		t.Fatalf("first request: got %d, want 200", code)
+	}
+	if code := do(); code != http.StatusTooManyRequests {
+		t.Fatalf("second request: got %d, want 429", code)
+	}
+}

--- a/horizon/internal/middleware/ratelimit_test.go
+++ b/horizon/internal/middleware/ratelimit_test.go
@@ -52,3 +52,37 @@ func TestIPRateLimiter_Middleware(t *testing.T) {
 		t.Fatalf("second request: got %d, want 429", code)
 	}
 }
+
+// TestIPRateLimiter_Refill verifies that the bucket refills over time: once
+// enough time has elapsed for a token to be replenished, a previously
+// rate-limited client is allowed again.
+func TestIPRateLimiter_Refill(t *testing.T) {
+	// 100 events/sec (one token every 10ms), burst 1.
+	l := NewIPRateLimiter(rate.Every(10*time.Millisecond), 1, time.Minute)
+	defer l.Stop()
+
+	const ip = "10.0.0.1"
+	if !l.Allow(ip) {
+		t.Fatal("first call should be allowed")
+	}
+	if l.Allow(ip) {
+		t.Fatal("second immediate call should be limited")
+	}
+
+	// Wait for the bucket to refill, then it should pass again.
+	time.Sleep(30 * time.Millisecond)
+	if !l.Allow(ip) {
+		t.Fatal("call after refill window should be allowed")
+	}
+}
+
+// TestNewIPRateLimiter_NonPositiveTTL ensures a non-positive ttl does not panic
+// (time.NewTicker panics on <= 0) and that the limiter is still usable.
+func TestNewIPRateLimiter_NonPositiveTTL(t *testing.T) {
+	for _, ttl := range []time.Duration{0, -time.Second} {
+		l := NewIPRateLimiter(rate.Every(time.Second), 1, ttl)
+		if !l.Allow("1.1.1.1") {
+			t.Fatalf("ttl=%v: limiter should allow the first call", ttl)
+		}
+	}
+}

--- a/horizon/pkg/httpframework/httpframework.go
+++ b/horizon/pkg/httpframework/httpframework.go
@@ -1,11 +1,13 @@
 package httpframework
 
 import (
+	"os"
+	"strings"
+	"sync"
+
 	"github.com/Meesho/BharatMLStack/horizon/pkg/middleware"
 	"github.com/gin-gonic/gin"
 	"github.com/rs/zerolog/log"
-	"os"
-	"sync"
 )
 
 var (
@@ -22,6 +24,24 @@ func Init(middlewares ...gin.HandlerFunc) {
 			gin.SetMode(gin.ReleaseMode)
 		}
 		router = gin.New()
+		// By default gin trusts all proxies, which makes c.ClientIP() honour a
+		// client-supplied X-Forwarded-For header. That lets a caller spoof their
+		// IP and bypass per-IP protections such as the /login rate limiter. Only
+		// trust the proxies explicitly listed in TRUSTED_PROXIES (comma
+		// separated CIDRs/IPs); if unset, trust none so ClientIP() falls back to
+		// the real remote address.
+		var trusted []string
+		if tp := strings.TrimSpace(os.Getenv("TRUSTED_PROXIES")); tp != "" {
+			for _, p := range strings.Split(tp, ",") {
+				if p = strings.TrimSpace(p); p != "" {
+					trusted = append(trusted, p)
+				}
+			}
+		}
+		if err := router.SetTrustedProxies(trusted); err != nil {
+			log.Error().Err(err).Msg("Failed to set trusted proxies; defaulting to trust none")
+			_ = router.SetTrustedProxies(nil)
+		}
 		middlewares = append(middlewares, middleware.HTTPLogger(), middleware.HTTPRecovery())
 		router.Use(middlewares...)
 	})


### PR DESCRIPTION
## Summary

The `POST /login` endpoint had no protection against brute-force or credential-stuffing attacks. There was no limit on the number of password attempts per account or per source IP, so an attacker could try unlimited password guesses against any known email address.

This PR adds two complementary, defence-in-depth controls.

## Changes

### 1. Per-IP rate limiting (`internal/middleware/ratelimit.go`)
- Token-bucket limiter keyed by client IP, built on `golang.org/x/time/rate`.
- Applied only to `POST /login`: ~5 attempts/minute with a burst of 5.
- Idle IP entries are evicted after 10 minutes to bound memory.
- Returns `429 Too Many Requests` when the bucket is exhausted.

### 2. Per-account lockout (`internal/auth/handler/auth.go`)
- After **5 consecutive failed logins** for the same email, the account is temporarily locked for **15 minutes**.
- A successful login resets the failure counter.
- Failures are recorded both for wrong passwords and for unknown emails routed through the same path, and the generic `invalid email or password` response is preserved to avoid user enumeration.

## Tests
- `internal/middleware/ratelimit_test.go` — limiter allows up to the burst then blocks, and recovers over time; per-IP isolation.
- `internal/auth/handler/auth_lockout_test.go` — account locks after the threshold (even with a subsequently correct password), a success resets the counter, and unknown accounts are not reported as locked.

These are the first tests added for the `internal/auth/handler` and rate-limit paths.

## Notes / follow-ups
- The lockout counter is **in-memory and therefore per-replica**. For a multi-replica deployment it should be backed by a shared store (Redis/DB) so the lockout is enforced globally; this is documented inline. The per-IP limiter has the same per-replica caveat.
- For `ClientIP()` to be trustworthy behind a proxy/LB, gin's `TrustedProxies` must be configured so the source IP cannot be spoofed via `X-Forwarded-For`.

## Dependencies
- Promotes `golang.org/x/time` from an indirect to a direct dependency (`go mod tidy`).
