### PR TITLE
fix(scylla): validate CQL identifiers to prevent injection

### DIFF
--- a/horizon/internal/online-feature-store/handler/online_feature_store.go
+++ b/horizon/internal/online-feature-store/handler/online_feature_store.go
@@ -10,6 +10,7 @@ import (
 
 	onlinefeaturestore "github.com/Meesho/BharatMLStack/horizon/internal/online-feature-store"
 	"github.com/Meesho/BharatMLStack/horizon/internal/repositories/scylla"
+	"github.com/Meesho/BharatMLStack/horizon/pkg/cqlident"
 	"github.com/Meesho/BharatMLStack/horizon/pkg/infra"
 
 	config2 "github.com/Meesho/BharatMLStack/horizon/internal/online-feature-store/config"
@@ -145,6 +146,18 @@ func (o *OnlineFeatureStore) RegisterStore(request *RegisterStoreRequest) (uint,
 	//check if dbType is valid
 	if confIdToDbTypeMap[strconv.Itoa(request.ConfId)] != request.DbType {
 		return 0, fmt.Errorf("invalid db type %s for conf id %d", request.DbType, request.ConfId)
+	}
+
+	// For scylla-backed stores the table/primary-key names end up in DDL that
+	// cannot be parameterized. Reject unsafe identifiers up front so a bad
+	// request is never even persisted as PENDING APPROVAL.
+	if request.DbType == "scylla" {
+		if err := cqlident.Validate("table", request.Table); err != nil {
+			return 0, err
+		}
+		if err := cqlident.ValidateAll("primary key", request.PrimaryKeys); err != nil {
+			return 0, err
+		}
 	}
 
 	payload, err := json.Marshal(request)

--- a/horizon/internal/online-feature-store/handler/online_feature_store.go
+++ b/horizon/internal/online-feature-store/handler/online_feature_store.go
@@ -155,6 +155,9 @@ func (o *OnlineFeatureStore) RegisterStore(request *RegisterStoreRequest) (uint,
 		if err := cqlident.Validate("table", request.Table); err != nil {
 			return 0, err
 		}
+		if len(request.PrimaryKeys) == 0 {
+			return 0, fmt.Errorf("at least one primary key is required for scylla store %q", request.Table)
+		}
 		if err := cqlident.ValidateAll("primary key", request.PrimaryKeys); err != nil {
 			return 0, err
 		}
@@ -193,7 +196,26 @@ func (o *OnlineFeatureStore) ProcessStore(request *ProcessStoreRequest) error {
 	}
 	var payload RegisterStoreRequest
 	if request.Status != "REJECTED" {
-		json.Unmarshal([]byte(e.Payload), &payload)
+		if err := json.Unmarshal([]byte(e.Payload), &payload); err != nil {
+			log.Error().Msgf("Error unmarshalling store payload for %d: %v", request.RequestId, err)
+			return err
+		}
+
+		// Re-validate identifiers before they reach the DDL. RegisterStore is the
+		// primary guard, but rows persisted before that check existed (or via any
+		// other code path) must not be trusted blindly here.
+		if payload.DbType == "scylla" {
+			if err := cqlident.Validate("table", payload.Table); err != nil {
+				return err
+			}
+			if len(payload.PrimaryKeys) == 0 {
+				return fmt.Errorf("at least one primary key is required for scylla store %q", payload.Table)
+			}
+			if err := cqlident.ValidateAll("primary key", payload.PrimaryKeys); err != nil {
+				return err
+			}
+		}
+
 		storeMap, err := o.Config.RegisterStore(payload.ConfId, payload.DbType, payload.Table, payload.PrimaryKeys, payload.TableTtl)
 		if err != nil {
 			log.Error().Msgf("Error Registering Store for %s , %s", payload.DbType, payload.Table)

--- a/horizon/internal/repositories/scylla/repository.go
+++ b/horizon/internal/repositories/scylla/repository.go
@@ -43,6 +43,9 @@ func (s *Scylla) CreateTable(tableName string, pkColumns []string, defaultTimeTo
 
 	// Validate every identifier before it is interpolated into the DDL.
 	// gocql cannot bind identifiers, so this is the guard against CQL injection.
+	if err := cqlident.Validate("keyspace", s.keySpace); err != nil {
+		return err
+	}
 	if err := cqlident.Validate("table", tableName); err != nil {
 		return err
 	}
@@ -100,10 +103,13 @@ func (s *Scylla) CreateTable(tableName string, pkColumns []string, defaultTimeTo
 func (s *Scylla) AddColumn(tableName string, column string) error {
 	log.Info().Msgf("Adding column %s to Scylla table: %s.%s", column, s.keySpace, tableName)
 
+	if err := cqlident.Validate("keyspace", s.keySpace); err != nil {
+		return err
+	}
 	if err := cqlident.Validate("table", tableName); err != nil {
 		return err
 	}
-	if err := cqlident.Validate("column", column); err != nil {
+	if err := cqlident.ValidateColumn(column); err != nil {
 		return err
 	}
 

--- a/horizon/internal/repositories/scylla/repository.go
+++ b/horizon/internal/repositories/scylla/repository.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Meesho/BharatMLStack/horizon/pkg/cqlident"
 	"github.com/Meesho/BharatMLStack/horizon/pkg/infra"
 	"github.com/gocql/gocql"
 	"github.com/rs/zerolog/log"
@@ -39,6 +40,15 @@ func NewRepository(connection *infra.ScyllaClusterConnection) (Store, error) {
 // CreateTable implements the Store interface method to create a table
 func (s *Scylla) CreateTable(tableName string, pkColumns []string, defaultTimeToLive int) error {
 	log.Info().Msgf("Creating Scylla table: %s in keyspace: %s", tableName, s.keySpace)
+
+	// Validate every identifier before it is interpolated into the DDL.
+	// gocql cannot bind identifiers, so this is the guard against CQL injection.
+	if err := cqlident.Validate("table", tableName); err != nil {
+		return err
+	}
+	if err := cqlident.ValidateAll("primary key", pkColumns); err != nil {
+		return err
+	}
 
 	// Build the column definitions
 	var columnDefs []string
@@ -89,6 +99,13 @@ func (s *Scylla) CreateTable(tableName string, pkColumns []string, defaultTimeTo
 // AddColumn implements the Store interface method to add a column to the table
 func (s *Scylla) AddColumn(tableName string, column string) error {
 	log.Info().Msgf("Adding column %s to Scylla table: %s.%s", column, s.keySpace, tableName)
+
+	if err := cqlident.Validate("table", tableName); err != nil {
+		return err
+	}
+	if err := cqlident.Validate("column", column); err != nil {
+		return err
+	}
 
 	query := fmt.Sprintf(addColumnQuery, s.keySpace, tableName, column)
 	log.Info().Msgf("Executing Scylla add column query: %s", query)

--- a/horizon/internal/repositories/scylla/repository_test.go
+++ b/horizon/internal/repositories/scylla/repository_test.go
@@ -1,0 +1,74 @@
+package scylla
+
+import (
+	"strings"
+	"testing"
+)
+
+// These tests verify that the Scylla DDL helpers reject unsafe identifiers
+// *before* they reach the (here nil) gocql session. Because validation happens
+// first, a malicious identifier returns a validation error rather than
+// panicking on the nil session — which is exactly the guarantee we want.
+
+func TestScylla_CreateTable_RejectsInjection(t *testing.T) {
+	s := &Scylla{keySpace: "ks"} // session intentionally nil
+
+	cases := []struct {
+		name      string
+		table     string
+		pkColumns []string
+	}{
+		{"bad table", "t (id text PRIMARY KEY); DROP KEYSPACE ks; --", []string{"id"}},
+		{"bad pk", "good_table", []string{"id text PRIMARY KEY) WITH x; --"}},
+		{"empty table", "", []string{"id"}},
+		{"pk with space", "good_table", []string{"id evil"}},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := s.CreateTable(c.table, c.pkColumns, 0); err == nil {
+				t.Fatalf("CreateTable(%q, %v) = nil, want validation error", c.table, c.pkColumns)
+			}
+		})
+	}
+}
+
+func TestScylla_AddColumn_RejectsInjection(t *testing.T) {
+	s := &Scylla{keySpace: "ks"}
+
+	cases := []struct {
+		name   string
+		table  string
+		column string
+	}{
+		{"bad column", "good_table", "c blob; DROP TABLE good_table; --"},
+		{"bad table", "bad table", "good_col"},
+		{"empty column", "good_table", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := s.AddColumn(c.table, c.column); err == nil {
+				t.Fatalf("AddColumn(%q, %q) = nil, want validation error", c.table, c.column)
+			}
+		})
+	}
+}
+
+func TestSkyeScylla_RejectsInjection(t *testing.T) {
+	s := &SkyeScylla{keySpace: "ks"}
+
+	if err := s.AddEmbeddingColumn("good_table", "c boolean; DROP TABLE x; --"); err == nil {
+		t.Error("AddEmbeddingColumn with injected column = nil, want error")
+	}
+	if err := s.AddAggregatorColumn("good_table", "bad;col"); err == nil {
+		t.Error("AddAggregatorColumn with injected column = nil, want error")
+	}
+	if err := s.CreateEmbeddingTable("t)", 0, []string{"v1"}); err == nil {
+		t.Error("CreateEmbeddingTable with injected table = nil, want error")
+	}
+	if err := s.CreateEmbeddingTable("good_table", 0, []string{"v1; DROP"}); err == nil {
+		t.Error("CreateEmbeddingTable with injected variant = nil, want error")
+	}
+	if err := s.CreateAggregatorTable(strings.Repeat("a", 200), 0); err == nil {
+		t.Error("CreateAggregatorTable with over-long table = nil, want error")
+	}
+}

--- a/horizon/internal/repositories/scylla/repository_test.go
+++ b/horizon/internal/repositories/scylla/repository_test.go
@@ -54,21 +54,40 @@ func TestScylla_AddColumn_RejectsInjection(t *testing.T) {
 }
 
 func TestSkyeScylla_RejectsInjection(t *testing.T) {
-	s := &SkyeScylla{keySpace: "ks"}
+	s := &SkyeScylla{keySpace: "ks"} // session intentionally nil
 
-	if err := s.AddEmbeddingColumn("good_table", "c boolean; DROP TABLE x; --"); err == nil {
-		t.Error("AddEmbeddingColumn with injected column = nil, want error")
+	cases := []struct {
+		name string
+		// fn invokes one Skye helper with an unsafe input; it must return a
+		// validation error before touching the nil session.
+		fn func() error
+	}{
+		{
+			"embedding column injection",
+			func() error { return s.AddEmbeddingColumn("good_table", "c boolean; DROP TABLE x; --") },
+		},
+		{
+			"aggregator column injection",
+			func() error { return s.AddAggregatorColumn("good_table", "bad;col") },
+		},
+		{
+			"embedding table injection",
+			func() error { return s.CreateEmbeddingTable("t)", 0, []string{"v1"}) },
+		},
+		// NOTE: variant-identifier validation now happens on the table-creation
+		// path (after the "already exists" check), so it can't be exercised here
+		// with a nil session. That path is unit-tested in
+		// pkg/cqlident: TestValidateColumn_NormalizedVariant.
+		{
+			"aggregator over-long table",
+			func() error { return s.CreateAggregatorTable(strings.Repeat("a", 200), 0) },
+		},
 	}
-	if err := s.AddAggregatorColumn("good_table", "bad;col"); err == nil {
-		t.Error("AddAggregatorColumn with injected column = nil, want error")
-	}
-	if err := s.CreateEmbeddingTable("t)", 0, []string{"v1"}); err == nil {
-		t.Error("CreateEmbeddingTable with injected table = nil, want error")
-	}
-	if err := s.CreateEmbeddingTable("good_table", 0, []string{"v1; DROP"}); err == nil {
-		t.Error("CreateEmbeddingTable with injected variant = nil, want error")
-	}
-	if err := s.CreateAggregatorTable(strings.Repeat("a", 200), 0); err == nil {
-		t.Error("CreateAggregatorTable with over-long table = nil, want error")
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if err := c.fn(); err == nil {
+				t.Fatalf("%s: got nil, want validation error", c.name)
+			}
+		})
 	}
 }

--- a/horizon/internal/repositories/scylla/skye_scylla.go
+++ b/horizon/internal/repositories/scylla/skye_scylla.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Meesho/BharatMLStack/horizon/pkg/cqlident"
 	"github.com/Meesho/BharatMLStack/horizon/pkg/infra"
 	"github.com/gocql/gocql"
 	"github.com/rs/zerolog/log"
@@ -76,6 +77,13 @@ func (s *SkyeScylla) tableExists(tableName string) (bool, error) {
 }
 
 func (s *SkyeScylla) CreateEmbeddingTable(tableName string, defaultTimeToLive int, variantsList []string) error {
+	// Validate identifiers before interpolating them into the DDL.
+	if err := cqlident.Validate("table", tableName); err != nil {
+		return err
+	}
+	if err := cqlident.ValidateAll("variant", variantsList); err != nil {
+		return err
+	}
 	// Check if table already exists
 	exists, err := s.tableExists(tableName)
 	if err != nil {
@@ -111,6 +119,12 @@ func (s *SkyeScylla) CreateEmbeddingTable(tableName string, defaultTimeToLive in
 }
 
 func (s *SkyeScylla) AddEmbeddingColumn(tableName string, columnName string) error {
+	if err := cqlident.Validate("table", tableName); err != nil {
+		return err
+	}
+	if err := cqlident.Validate("column", columnName); err != nil {
+		return err
+	}
 	query := fmt.Sprintf(addBoolColumnQuery, s.keySpace, tableName, columnName)
 
 	err := s.session.Query(query).Exec()
@@ -131,6 +145,9 @@ func (s *SkyeScylla) AddEmbeddingColumn(tableName string, columnName string) err
 }
 
 func (s *SkyeScylla) CreateAggregatorTable(tableName string, defaultTimeToLive int) error {
+	if err := cqlident.Validate("table", tableName); err != nil {
+		return err
+	}
 	// Check if table already exists
 	exists, err := s.tableExists(tableName)
 	if err != nil {
@@ -159,6 +176,12 @@ func (s *SkyeScylla) CreateAggregatorTable(tableName string, defaultTimeToLive i
 }
 
 func (s *SkyeScylla) AddAggregatorColumn(tableName string, columnName string) error {
+	if err := cqlident.Validate("table", tableName); err != nil {
+		return err
+	}
+	if err := cqlident.Validate("column", columnName); err != nil {
+		return err
+	}
 	query := fmt.Sprintf(addTextColumnQuery, s.keySpace, tableName, columnName)
 
 	err := s.session.Query(query).Exec()

--- a/horizon/internal/repositories/scylla/skye_scylla.go
+++ b/horizon/internal/repositories/scylla/skye_scylla.go
@@ -78,12 +78,27 @@ func (s *SkyeScylla) tableExists(tableName string) (bool, error) {
 
 func (s *SkyeScylla) CreateEmbeddingTable(tableName string, defaultTimeToLive int, variantsList []string) error {
 	// Validate identifiers before interpolating them into the DDL.
+	if err := cqlident.Validate("keyspace", s.keySpace); err != nil {
+		return err
+	}
 	if err := cqlident.Validate("table", tableName); err != nil {
 		return err
 	}
-	if err := cqlident.ValidateAll("variant", variantsList); err != nil {
-		return err
+	// Build and validate variant column definitions up front, before any DB
+	// roundtrip, so an invalid identifier is rejected without side effects.
+	var variantColumns strings.Builder
+	for _, variant := range variantsList {
+		// Convert variant name to snake_case and append _to_be_indexed. The
+		// *generated* column name is what gets interpolated into the DDL, so we
+		// validate that (not the raw variant) — this still rejects injection
+		// while allowing supported variants such as "model-v1".
+		variantColumnName := strings.ToLower(strings.ReplaceAll(variant, "-", "_")) + "_to_be_indexed"
+		if err := cqlident.ValidateColumn(variantColumnName); err != nil {
+			return fmt.Errorf("invalid variant %q: %w", variant, err)
+		}
+		variantColumns.WriteString(fmt.Sprintf(",\n\t\t%s boolean", variantColumnName))
 	}
+
 	// Check if table already exists
 	exists, err := s.tableExists(tableName)
 	if err != nil {
@@ -95,13 +110,6 @@ func (s *SkyeScylla) CreateEmbeddingTable(tableName string, defaultTimeToLive in
 		log.Error().Str("keyspace", s.keySpace).Str("table", tableName).
 			Msg("Embedding table already exists, skipping creation")
 		return nil
-	}
-	// Build variant column definitions
-	var variantColumns strings.Builder
-	for _, variant := range variantsList {
-		// Convert variant name to snake_case and append _to_be_indexed
-		variantColumnName := strings.ToLower(strings.ReplaceAll(variant, "-", "_")) + "_to_be_indexed"
-		variantColumns.WriteString(fmt.Sprintf(",\n\t\t%s boolean", variantColumnName))
 	}
 
 	query := fmt.Sprintf(createEmbeddingTableQueryBase, s.keySpace, tableName, variantColumns.String(), defaultTimeToLive)
@@ -119,10 +127,13 @@ func (s *SkyeScylla) CreateEmbeddingTable(tableName string, defaultTimeToLive in
 }
 
 func (s *SkyeScylla) AddEmbeddingColumn(tableName string, columnName string) error {
+	if err := cqlident.Validate("keyspace", s.keySpace); err != nil {
+		return err
+	}
 	if err := cqlident.Validate("table", tableName); err != nil {
 		return err
 	}
-	if err := cqlident.Validate("column", columnName); err != nil {
+	if err := cqlident.ValidateColumn(columnName); err != nil {
 		return err
 	}
 	query := fmt.Sprintf(addBoolColumnQuery, s.keySpace, tableName, columnName)
@@ -145,6 +156,9 @@ func (s *SkyeScylla) AddEmbeddingColumn(tableName string, columnName string) err
 }
 
 func (s *SkyeScylla) CreateAggregatorTable(tableName string, defaultTimeToLive int) error {
+	if err := cqlident.Validate("keyspace", s.keySpace); err != nil {
+		return err
+	}
 	if err := cqlident.Validate("table", tableName); err != nil {
 		return err
 	}
@@ -176,10 +190,13 @@ func (s *SkyeScylla) CreateAggregatorTable(tableName string, defaultTimeToLive i
 }
 
 func (s *SkyeScylla) AddAggregatorColumn(tableName string, columnName string) error {
+	if err := cqlident.Validate("keyspace", s.keySpace); err != nil {
+		return err
+	}
 	if err := cqlident.Validate("table", tableName); err != nil {
 		return err
 	}
-	if err := cqlident.Validate("column", columnName); err != nil {
+	if err := cqlident.ValidateColumn(columnName); err != nil {
 		return err
 	}
 	query := fmt.Sprintf(addTextColumnQuery, s.keySpace, tableName, columnName)

--- a/horizon/internal/repositories/scylla/skye_scylla.go
+++ b/horizon/internal/repositories/scylla/skye_scylla.go
@@ -84,8 +84,23 @@ func (s *SkyeScylla) CreateEmbeddingTable(tableName string, defaultTimeToLive in
 	if err := cqlident.Validate("table", tableName); err != nil {
 		return err
 	}
-	// Build and validate variant column definitions up front, before any DB
-	// roundtrip, so an invalid identifier is rejected without side effects.
+
+	// Check if table already exists before doing any per-variant work, so the
+	// idempotent reconciliation fast path (table already present) stays cheap.
+	exists, err := s.tableExists(tableName)
+	if err != nil {
+		log.Error().Err(err).Str("keyspace", s.keySpace).Str("table", tableName).
+			Msg("Failed to check if embedding table exists")
+		return fmt.Errorf("failed to check if table exists: %w", err)
+	}
+	if exists {
+		log.Error().Str("keyspace", s.keySpace).Str("table", tableName).
+			Msg("Embedding table already exists, skipping creation")
+		return nil
+	}
+
+	// Build and validate variant column definitions only once we know the table
+	// needs to be created.
 	var variantColumns strings.Builder
 	for _, variant := range variantsList {
 		// Convert variant name to snake_case and append _to_be_indexed. The
@@ -97,19 +112,6 @@ func (s *SkyeScylla) CreateEmbeddingTable(tableName string, defaultTimeToLive in
 			return fmt.Errorf("invalid variant %q: %w", variant, err)
 		}
 		variantColumns.WriteString(fmt.Sprintf(",\n\t\t%s boolean", variantColumnName))
-	}
-
-	// Check if table already exists
-	exists, err := s.tableExists(tableName)
-	if err != nil {
-		log.Error().Err(err).Str("keyspace", s.keySpace).Str("table", tableName).
-			Msg("Failed to check if embedding table exists")
-		return fmt.Errorf("failed to check if table exists: %w", err)
-	}
-	if exists {
-		log.Error().Str("keyspace", s.keySpace).Str("table", tableName).
-			Msg("Embedding table already exists, skipping creation")
-		return nil
 	}
 
 	query := fmt.Sprintf(createEmbeddingTableQueryBase, s.keySpace, tableName, variantColumns.String(), defaultTimeToLive)

--- a/horizon/pkg/cqlident/cqlident.go
+++ b/horizon/pkg/cqlident/cqlident.go
@@ -16,9 +16,11 @@ import (
 
 const (
 	// maxIdentLen bounds keyspace / table / primary-key names. Cassandra and
-	// Scylla limit these unquoted identifiers to 48 characters; we allow a
-	// little headroom while still bounding the value.
-	maxIdentLen = 64
+	// Scylla cap these unquoted identifiers at 48 characters, so we use the
+	// same limit: a longer name would only pass this check and then fail at
+	// DDL time, which is exactly the late failure this validator exists to
+	// prevent.
+	maxIdentLen = 48
 
 	// maxColumnLen bounds column names. Feature-store and Skye column names are
 	// generated from feature labels / variants and can legitimately be longer

--- a/horizon/pkg/cqlident/cqlident.go
+++ b/horizon/pkg/cqlident/cqlident.go
@@ -14,10 +14,17 @@ import (
 	"regexp"
 )
 
-// maxIdentLen is a defensive upper bound. Cassandra/Scylla limit unquoted
-// keyspace and table names to 48 characters; we allow a little more headroom
-// for generated column names while still bounding the value.
-const maxIdentLen = 64
+const (
+	// maxIdentLen bounds keyspace / table / primary-key names. Cassandra and
+	// Scylla limit these unquoted identifiers to 48 characters; we allow a
+	// little headroom while still bounding the value.
+	maxIdentLen = 64
+
+	// maxColumnLen bounds column names. Feature-store and Skye column names are
+	// generated from feature labels / variants and can legitimately be longer
+	// than a table name, so they get a larger (but still finite) cap.
+	maxColumnLen = 128
+)
 
 // identRe matches an unquoted CQL identifier: a letter or underscore followed
 // by letters, digits or underscores. This intentionally rejects whitespace,
@@ -25,15 +32,26 @@ const maxIdentLen = 64
 // to break out of the intended statement.
 var identRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 
-// Validate returns an error if name is not a safe, unquoted CQL identifier.
-// kind is used only to produce a helpful error message (e.g. "table",
-// "column", "primary key").
+// Validate returns an error if name is not a safe, unquoted CQL identifier
+// suitable for a keyspace, table or primary-key name. kind is used only to
+// produce a helpful error message (e.g. "table", "primary key").
 func Validate(kind, name string) error {
+	return validate(kind, name, maxIdentLen)
+}
+
+// ValidateColumn validates a column identifier, allowing the larger column
+// length cap. Use this for column names (including generated ones) rather than
+// Validate, which uses the stricter table/keyspace cap.
+func ValidateColumn(name string) error {
+	return validate("column", name, maxColumnLen)
+}
+
+func validate(kind, name string, maxLen int) error {
 	if name == "" {
 		return fmt.Errorf("invalid %s identifier: must not be empty", kind)
 	}
-	if len(name) > maxIdentLen {
-		return fmt.Errorf("invalid %s identifier %q: must be at most %d characters", kind, name, maxIdentLen)
+	if len(name) > maxLen {
+		return fmt.Errorf("invalid %s identifier %q: must be at most %d characters", kind, name, maxLen)
 	}
 	if !identRe.MatchString(name) {
 		return fmt.Errorf("invalid %s identifier %q: must match [a-zA-Z_][a-zA-Z0-9_]*", kind, name)

--- a/horizon/pkg/cqlident/cqlident.go
+++ b/horizon/pkg/cqlident/cqlident.go
@@ -1,0 +1,52 @@
+// Package cqlident provides strict validation for CQL identifiers
+// (keyspace / table / column names).
+//
+// gocql cannot bind identifiers as query parameters, so any DDL that needs a
+// dynamic table or column name has to build the statement with string
+// interpolation. To keep that safe, every identifier that flows into such a
+// statement MUST be validated against the allow-list below first, otherwise a
+// crafted value (e.g. "t (id text PRIMARY KEY); DROP KEYSPACE x; --") could
+// inject arbitrary CQL.
+package cqlident
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// maxIdentLen is a defensive upper bound. Cassandra/Scylla limit unquoted
+// keyspace and table names to 48 characters; we allow a little more headroom
+// for generated column names while still bounding the value.
+const maxIdentLen = 64
+
+// identRe matches an unquoted CQL identifier: a letter or underscore followed
+// by letters, digits or underscores. This intentionally rejects whitespace,
+// quotes, semicolons, parentheses and every other character that could be used
+// to break out of the intended statement.
+var identRe = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
+
+// Validate returns an error if name is not a safe, unquoted CQL identifier.
+// kind is used only to produce a helpful error message (e.g. "table",
+// "column", "primary key").
+func Validate(kind, name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid %s identifier: must not be empty", kind)
+	}
+	if len(name) > maxIdentLen {
+		return fmt.Errorf("invalid %s identifier %q: must be at most %d characters", kind, name, maxIdentLen)
+	}
+	if !identRe.MatchString(name) {
+		return fmt.Errorf("invalid %s identifier %q: must match [a-zA-Z_][a-zA-Z0-9_]*", kind, name)
+	}
+	return nil
+}
+
+// ValidateAll validates every identifier in names, returning the first error.
+func ValidateAll(kind string, names []string) error {
+	for _, n := range names {
+		if err := Validate(kind, n); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/horizon/pkg/cqlident/cqlident_test.go
+++ b/horizon/pkg/cqlident/cqlident_test.go
@@ -1,0 +1,59 @@
+package cqlident
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidate_Valid(t *testing.T) {
+	valid := []string{
+		"users",
+		"feature_group_1",
+		"_internal",
+		"seg_42",
+		"a",
+		"A",
+		"Col123",
+		strings.Repeat("a", maxIdentLen), // exactly at the limit
+	}
+	for _, name := range valid {
+		if err := Validate("table", name); err != nil {
+			t.Errorf("Validate(%q) returned unexpected error: %v", name, err)
+		}
+	}
+}
+
+func TestValidate_Invalid(t *testing.T) {
+	// These are the injection / malformed cases that MUST be rejected.
+	invalid := []string{
+		"",                                    // empty
+		"1abc",                                // starts with a digit
+		"foo bar",                             // whitespace
+		"foo;DROP KEYSPACE x",                 // statement separator
+		"foo)",                                // closing paren breakout
+		"t (id text PRIMARY KEY); DROP TABLE", // classic stacked-query payload
+		"foo-bar",                             // hyphen not allowed (unquoted)
+		"foo.bar",                             // dotted name
+		`foo"`,                                // quote
+		"foo--comment",                        // CQL comment
+		"naïve",                               // non-ASCII
+		strings.Repeat("a", maxIdentLen+1),    // over the length cap
+	}
+	for _, name := range invalid {
+		if err := Validate("column", name); err == nil {
+			t.Errorf("Validate(%q) = nil, want error", name)
+		}
+	}
+}
+
+func TestValidateAll(t *testing.T) {
+	if err := ValidateAll("primary key", []string{"id", "tenant_id"}); err != nil {
+		t.Errorf("ValidateAll(valid) returned error: %v", err)
+	}
+	if err := ValidateAll("primary key", []string{"id", "bad;name"}); err == nil {
+		t.Error("ValidateAll(with invalid) = nil, want error")
+	}
+	if err := ValidateAll("primary key", nil); err != nil {
+		t.Errorf("ValidateAll(nil) returned error: %v", err)
+	}
+}

--- a/horizon/pkg/cqlident/cqlident_test.go
+++ b/horizon/pkg/cqlident/cqlident_test.go
@@ -23,6 +23,31 @@ func TestValidate_Valid(t *testing.T) {
 	}
 }
 
+func TestValidateColumn_LengthCap(t *testing.T) {
+	// A column name longer than the table cap but within the column cap is
+	// valid for ValidateColumn but rejected by Validate.
+	name := strings.Repeat("c", maxIdentLen+1)
+	if err := ValidateColumn(name); err != nil {
+		t.Errorf("ValidateColumn(%d chars) returned unexpected error: %v", len(name), err)
+	}
+	if err := Validate("table", name); err == nil {
+		t.Errorf("Validate(%d chars) = nil, want length error", len(name))
+	}
+
+	// Exactly at the column cap is allowed; one over is not.
+	if err := ValidateColumn(strings.Repeat("c", maxColumnLen)); err != nil {
+		t.Errorf("ValidateColumn at maxColumnLen returned error: %v", err)
+	}
+	if err := ValidateColumn(strings.Repeat("c", maxColumnLen+1)); err == nil {
+		t.Error("ValidateColumn over maxColumnLen = nil, want error")
+	}
+
+	// Injection is still rejected regardless of the larger cap.
+	if err := ValidateColumn("c boolean; DROP TABLE x; --"); err == nil {
+		t.Error("ValidateColumn(injection) = nil, want error")
+	}
+}
+
 func TestValidate_Invalid(t *testing.T) {
 	// These are the injection / malformed cases that MUST be rejected.
 	invalid := []string{
@@ -55,5 +80,22 @@ func TestValidateAll(t *testing.T) {
 	}
 	if err := ValidateAll("primary key", nil); err != nil {
 		t.Errorf("ValidateAll(nil) returned error: %v", err)
+	}
+}
+
+// TestValidateColumn_NormalizedVariant mirrors the transform SkyeScylla applies
+// to embedding variants (hyphen -> underscore, lower-cased, suffixed). The
+// resulting column name must be accepted, while a variant carrying an injection
+// payload must still be rejected after normalization.
+func TestValidateColumn_NormalizedVariant(t *testing.T) {
+	normalize := func(variant string) string {
+		return strings.ToLower(strings.ReplaceAll(variant, "-", "_")) + "_to_be_indexed"
+	}
+
+	if err := ValidateColumn(normalize("model-v1")); err != nil {
+		t.Errorf("normalized variant %q rejected: %v", "model-v1", err)
+	}
+	if err := ValidateColumn(normalize("v1; DROP")); err == nil {
+		t.Error("normalized injection variant = nil, want error")
 	}
 }


### PR DESCRIPTION
## Summary

Several Scylla DDL statements build CQL by string-interpolating table, column, and primary-key names with `fmt.Sprintf`, because gocql cannot bind identifiers (only values). Some of these identifiers originate from request payloads — e.g. `RegisterStoreRequest.Table` / `PrimaryKeys` and the Skye filter `ColumnName`. Because the values were not validated, a crafted identifier containing CQL control characters could break out of the intended statement and inject additional CQL (a classic injection via the one place parameter binding cannot cover).

This PR closes that gap by validating every identifier that is interpolated into CQL against a strict allow-list before it is used or persisted.

## Changes

### New `pkg/cqlident` validator
- Allows only identifiers matching `^[a-zA-Z_][a-zA-Z0-9_]*$`, with a length cap.
- Rejects anything containing whitespace, quotes, semicolons, comment markers, or other CQL metacharacters.
- Unit-tested with both valid identifiers and representative malicious inputs.

### Enforcement at the data layer (`internal/repositories/scylla`)
- `CreateTable` / `AddColumn` validate the table and column names before constructing DDL.
- The Skye helpers — `CreateEmbeddingTable`, `AddEmbeddingColumn`, `CreateAggregatorTable`, `AddAggregatorColumn` — validate their identifiers as well.

### Enforcement at the request boundary (`internal/online-feature-store/handler`)
- `RegisterStore` rejects unsafe table and primary-key names up front, so malformed input is never persisted as `PENDING APPROVAL` and never reaches the DDL path.

## Tests
- `pkg/cqlident/cqlident_test.go` — allow-list accepts valid names and rejects injection payloads.
- `internal/repositories/scylla/repository_test.go` — proves injection-style identifiers are rejected before any session interaction.

These are the first tests added for the `scylla` repository package.

## Notes / follow-ups
- Defence is centralized in `pkg/cqlident` so future call sites can reuse the same validator rather than re-deriving the rules.
- A separate minor cleanup (parameterizing the `tableExistsQuery` value bind) is noted for a follow-up and is not required for this fix.
